### PR TITLE
Do not assert existence of access switch for a MAC

### DIFF
--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -1204,8 +1204,8 @@ class FaucetStateCollector:
     def _update_learned_macs_metrics(self):
         for mac in self.learned_macs:
             switch, port = self._get_access_switch(mac)
-            assert port and switch, 'Could not find access switch for mac %s' % mac
-            self._update_learned_macs_metric(mac, switch, port)
+            if switch and port:
+                self._update_learned_macs_metric(mac, switch, port)
 
     def _update_learned_macs_metric(self, mac, switch_name, port, expire=False):
         if not self.faucet_config.get(DPS_CFG):


### PR DESCRIPTION
We cannot gurantee that the acces switch exists by the time when this method is called.