### PR TITLE
Output augmented include files to faucet directory

### DIFF
--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -273,7 +273,8 @@ class Faucetizer:
 
     def get_dva_state(self, switch, port):
         """Get DVA state"""
-        return self._vlan_states.get(switch, {}).get(port)
+        with self._lock:
+            return self._vlan_states.get(switch, {}).get(port)
 
 
 def load_devices_state(file):


### PR DESCRIPTION
Augmented include files, mainly the .yaml files for the ACLs, were written to FORCH_CONFIG_DIR previously. Now making forch write them to FAUCET_CONFIG_DIR instead.