### PR TITLE
Expose faucet config warning through API and Varz

### DIFF
--- a/bin/stack_functions
+++ b/bin/stack_functions
@@ -399,9 +399,9 @@ function validate_radius_varz {
     echo validating
     set -x
     timeouts=$(wget 0.0.0.0:8302 -O- | grep radius_query_timeouts_total | \
-		   grep -v 'HELP\|TYPE' | awk '{print $2}')
+                   grep -v 'HELP\|TYPE' | awk '{print $2}')
     responses=$(wget 0.0.0.0:8302 -O- | grep radius_query_responses_total | \
-		    grep -v 'HELP\|TYPE' | awk '{print $2}')
+                    grep -v 'HELP\|TYPE' | awk '{print $2}')
     timeouts=${timeouts%.0}
     responses=${responses%.0}
     echo Radius results $((timeouts > 0)) $((responses > 0)) | tee -a $TEST_RESULTS
@@ -412,6 +412,6 @@ function test_varz_value {
     port=$2
     path=$3
     query_path=0.0.0.0:$port/$path
-    value=$( printf "%.0f" $(wget $query_path -O- | grep $varz | grep -v 'HELP\|TYPE' | awk '{print $2'}) )
+    value=$( printf "%.0f" $(wget $query_path -O- | grep $varz | grep -v 'HELP\|TYPE' | awk '{print $2}') )
     echo $varz $value | tee -a $TEST_RESULTS
 }

--- a/etc/test_stack.out
+++ b/etc/test_stack.out
@@ -3,6 +3,8 @@ supercalifragilisticexpialidocious
 port_lacp_state{dp_id="0xb1",dp_name="nz-kiwi-t1sw1",port="28",port_description="egress"} 3.0
 port_lacp_state{dp_id="0xb2",dp_name="nz-kiwi-t1sw2",port="28",port_description="egress"} 0.0
 "0e:00:00:00:02:03"
+"faucet_dp_mac for DPs are not identical"
+faucet_config_warning_count 1
 %%% initial solid state
 Starting stack-solid test...
 (UNKNOWN) [192.168.1.1] 23 (?) : Connection timed out

--- a/forch/forch_metrics.py
+++ b/forch/forch_metrics.py
@@ -89,6 +89,9 @@ class ForchMetrics():
         self._add_var(
             'dataplane_packet_count_vlan', 'number of packets in vlan', Gauge, ['vlan'])
 
+        self._add_var('faucet_config_warning_count', 'Count of Faucet configuration warnings', Gauge)
+        self._add_var('faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'warning'])
+
     def get_metrics(self, path, params):
         """Return metric list in printable form"""
         return generate_latest(self._reg).decode('utf-8')

--- a/forch/forch_metrics.py
+++ b/forch/forch_metrics.py
@@ -90,7 +90,7 @@ class ForchMetrics():
             'dataplane_packet_count_vlan', 'number of packets in vlan', Gauge, ['vlan'])
 
         self._add_var('faucet_config_warning_count', 'Count of Faucet configuration warnings', Gauge)
-        self._add_var('faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'warning'])
+        self._add_var('faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'message'])
 
     def get_metrics(self, path, params):
         """Return metric list in printable form"""

--- a/forch/forch_metrics.py
+++ b/forch/forch_metrics.py
@@ -89,8 +89,10 @@ class ForchMetrics():
         self._add_var(
             'dataplane_packet_count_vlan', 'number of packets in vlan', Gauge, ['vlan'])
 
-        self._add_var('faucet_config_warning_count', 'Count of Faucet configuration warnings', Gauge)
-        self._add_var('faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'message'])
+        self._add_var(
+            'faucet_config_warning_count', 'Count of Faucet configuration warnings', Gauge)
+        self._add_var(
+            'faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'message'])
 
     def get_metrics(self, path, params):
         """Return metric list in printable form"""

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -633,7 +633,7 @@ class Forchestrator:
         self._metrics.update_var(
             'faucet_config_warning_count', len(self._config_summary.warnings))
         for warning_key, warning_msg in self._config_summary.warnings.items():
-            self._metrics.update_var('faucet_config_warning', 0, warning_msg)
+            self._metrics.update_var('faucet_config_warning', 0, [warning_key, warning_msg])
 
     def _populate_versions(self, versions):
         versions.forch = __version__

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -694,16 +694,16 @@ class Forchestrator:
         """Get overall config from faucet config file"""
         try:
             _, _, behavioral_config = self._get_faucet_config()
-            behavioral_config_map = {
-                'content': behavioral_config,
+            faucet_config_map = {
+                'behavioral': behavioral_config,
                 'warnings': dict(self._config_summary.warnings)
             }
             reply = {
-                'faucet_behavioral': behavioral_config_map,
+                'faucet': faucet_config_map,
                 'forch': proto_dict(self._config)
             }
             if self._faucetizer:
-                reply['faucet_structural'] = self._faucetizer.get_structural_config()
+                reply['faucet']['structural'] = self._faucetizer.get_structural_config()
             return self._augment_state_reply(reply, path)
         except Exception as e:
             return f"Cannot read faucet config: {e}"

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -632,7 +632,7 @@ class Forchestrator:
     def _update_config_warning_varz(self):
         self._metrics.update_var(
             'faucet_config_warning_count', len(self._config_summary.warnings))
-        for warning_key, warning_msg in self._config_summary.warnings:
+        for warning_key, warning_msg in self._config_summary.warnings.items():
             self._metrics.update_var('faucet_config_warning', 0, warning_msg)
 
     def _populate_versions(self, versions):

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -633,7 +633,7 @@ class Forchestrator:
         self._metrics.update_var(
             'faucet_config_warning_count', len(self._config_summary.warnings))
         for warning_key, warning_msg in self._config_summary.warnings.items():
-            self._metrics.update_var('faucet_config_warning', 0, [warning_key, warning_msg])
+            self._metrics.update_var('faucet_config_warning', 1, [warning_key, warning_msg])
 
     def _populate_versions(self, versions):
         versions.forch = __version__

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -687,8 +687,12 @@ class Forchestrator:
         """Get overall config from faucet config file"""
         try:
             _, _, behavioral_config = self._get_faucet_config()
+            behavioral_config_map = {
+                'content': behavioral_config,
+                'warnings': proto_dict(self._config_summary.warnings)
+            }
             reply = {
-                'faucet_behavioral': behavioral_config,
+                'faucet_behavioral': behavioral_config_map,
                 'forch': proto_dict(self._config)
             }
             if self._faucetizer:

--- a/testing/test_access
+++ b/testing/test_access
@@ -44,10 +44,10 @@ function test_dva {
 
     api_result=$fout_dir/sys_config.json
     echo "@sys_config $fdesc" | tee -a $TEST_RESULTS
-    jq '.faucet_structural.dps."nz-kiwi-t2sw1".interfaces."1".max_hosts' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.dps."nz-kiwi-t2sw2".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.dps."nz-kiwi-t2sw3".interfaces."1".native_vlan' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.dps."nz-kiwi-t2sw3".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet_structural.content.dps."nz-kiwi-t2sw1".interfaces."1".max_hosts' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw2".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3".interfaces."1".native_vlan' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
 
     api_result=$fout_dir/dataplane_state.json
     echo "@dataplane_state $fdesc" | tee -a $TEST_RESULTS

--- a/testing/test_access
+++ b/testing/test_access
@@ -44,10 +44,10 @@ function test_dva {
 
     api_result=$fout_dir/sys_config.json
     echo "@sys_config $fdesc" | tee -a $TEST_RESULTS
-    jq '.faucet_structural.content.dps."nz-kiwi-t2sw1".interfaces."1".max_hosts' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw2".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3".interfaces."1".native_vlan' $api_result | tee -a $TEST_RESULTS
-    jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet.structural.dps."nz-kiwi-t2sw1".interfaces."1".max_hosts' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet.behavioral.dps."nz-kiwi-t2sw2".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet.behavioral.dps."nz-kiwi-t2sw3".interfaces."1".native_vlan' $api_result | tee -a $TEST_RESULTS
+    jq '.faucet.behavioral.dps."nz-kiwi-t2sw3".interfaces."1".acls_in[0]' $api_result | tee -a $TEST_RESULTS
 
     api_result=$fout_dir/dataplane_state.json
     echo "@dataplane_state $fdesc" | tee -a $TEST_RESULTS

--- a/testing/test_stack
+++ b/testing/test_stack
@@ -65,8 +65,8 @@ fgrep "Network Operations Administrative Helper" $OUT_DIR/index.html || exit 1
 curl http://$CONTROLLER_NAME:9019/protos.html > $OUT_DIR/protos.html
 fgrep "forch/proto/system_state.proto" $OUT_DIR/protos.html || exit 1
 curl http://$CONTROLLER_NAME:9019/sys_config > $OUT_DIR/sys_config.json
-jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3"'.faucet_dp_mac $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
-jq '.faucet_behavioral.warnings.faucet_dp_mac' $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
+jq '.faucet.behavioral.dps."nz-kiwi-t2sw3"'.faucet_dp_mac $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
+jq '.faucet.warnings.faucet_dp_mac' $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
 test_varz_value faucet_config_warning_count 8302 forch
 
 echo %%% initial solid state | tee -a $TEST_RESULTS

--- a/testing/test_stack
+++ b/testing/test_stack
@@ -66,6 +66,8 @@ curl http://$CONTROLLER_NAME:9019/protos.html > $OUT_DIR/protos.html
 fgrep "forch/proto/system_state.proto" $OUT_DIR/protos.html || exit 1
 curl http://$CONTROLLER_NAME:9019/sys_config > $OUT_DIR/sys_config.json
 jq '.faucet_behavioral.dps."nz-kiwi-t2sw3"'.faucet_dp_mac $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
+jq '.faucet_behavioral.warnings.faucet_dp_mac' $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
+test_varz_value faucet_config_warning_count 8302 forch
 
 echo %%% initial solid state | tee -a $TEST_RESULTS
 test_stack -solid

--- a/testing/test_stack
+++ b/testing/test_stack
@@ -65,7 +65,7 @@ fgrep "Network Operations Administrative Helper" $OUT_DIR/index.html || exit 1
 curl http://$CONTROLLER_NAME:9019/protos.html > $OUT_DIR/protos.html
 fgrep "forch/proto/system_state.proto" $OUT_DIR/protos.html || exit 1
 curl http://$CONTROLLER_NAME:9019/sys_config > $OUT_DIR/sys_config.json
-jq '.faucet_behavioral.dps."nz-kiwi-t2sw3"'.faucet_dp_mac $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
+jq '.faucet_behavioral.content.dps."nz-kiwi-t2sw3"'.faucet_dp_mac $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
 jq '.faucet_behavioral.warnings.faucet_dp_mac' $OUT_DIR/sys_config.json | tee -a $TEST_RESULTS
 test_varz_value faucet_config_warning_count 8302 forch
 


### PR DESCRIPTION
Example of varz:
faucet_config_warning_count 2.0
faucet_config_warning{key="faucet_dp_mac",message="faucet_dp_mac for DPs are not identical"} 1.0
faucet_config_warning{key="nz-kiwi-t1sw2",message="faucet_dp_mac not defined"} 1.0