### PR TITLE
Improve stack test checking

### DIFF
--- a/bin/compile_ovs
+++ b/bin/compile_ovs
@@ -21,7 +21,7 @@ git clone https://github.com/openvswitch/ovs.git
 
 cd ovs
 
-git checkout v2.12.0
+git checkout v2.13.0
 
 ./boot.sh
 

--- a/bin/stack_functions
+++ b/bin/stack_functions
@@ -192,14 +192,14 @@ function test_stack {
     mkdir -p $nodes_dir
 
     echo $desc Capturing pcaps for $cap_length seconds...
-    tcpsudo="sudo tcpdump -Z root"
-    timeout $cap_length $tcpsudo -eni t1sw1-eth6 -w $t1sw1p6_pcap &
-    timeout $cap_length $tcpsudo -Q out -eni t1sw1-eth28 -w $t1sw1p28_pcap &
-    timeout $cap_length $tcpsudo -Q out -eni t1sw2-eth28 -w $t1sw2p28_pcap &
-    timeout $cap_length $tcpsudo -Q out -eni faux-1 -w $t2sw1p1_pcap &
-    timeout $cap_length $tcpsudo -eni t2sw1-eth50 -w $t2sw1p50_pcap &
-    timeout $cap_length $tcpsudo -eni t2sw1-eth52 -w $t2sw1p52_pcap &
-    timeout $cap_length $tcpsudo -Q out -eni faux-2 -w $t2sw2p1_pcap &
+    tcpsudo="sudo timeout $cap_length tcpdump --immediate-mode -Z root"
+    $tcpsudo -eni t1sw1-eth6 -w $t1sw1p6_pcap &
+    $tcpsudo -Q out -eni t1sw1-eth28 -w $t1sw1p28_pcap &
+    $tcpsudo -Q out -eni t1sw2-eth28 -w $t1sw2p28_pcap &
+    $tcpsudo -Q out -eni faux-1 -w $t2sw1p1_pcap &
+    $tcpsudo -eni t2sw1-eth50 -w $t2sw1p50_pcap &
+    $tcpsudo -eni t2sw1-eth52 -w $t2sw1p52_pcap &
+    $tcpsudo -Q out -eni faux-2 -w $t2sw2p1_pcap &
     sleep 5
 
     echo $desc Simple tests...
@@ -228,18 +228,20 @@ function test_stack {
     sleep $cap_length
     sudo chown -R $USER $desc_dir
 
-    bcount6=$(tcpdump -en -r $t1sw1p6_pcap | wc -l) 2>/dev/null
-    bcount50=$(tcpdump -en -r $t2sw1p50_pcap | wc -l) 2>/dev/null
-    bcount52=$(tcpdump -en -r $t2sw1p52_pcap | wc -l) 2>/dev/null
-    bcount_total=$((bcount50 + bcount52))
-    echo $desc pcap count is $bcount6 $bcount50 $bcount52 $bcount_total
-    echo pcap sane $((bcount6 > 0)) $((bcount6 < 180)) \
-         $((bcount_total > 100)) $((bcount_total < 220)) | tee -a $TEST_RESULTS
+    pcount6a=$(tcpdump -en -r $t1sw1p6_pcap vlan | wc -l) 2>/dev/null
+    pcount6i=$(tcpdump -en -r $t1sw1p6_pcap vlan and icmp | wc -l) 2>/dev/null
+    pcount50=$(tcpdump -en -r $t2sw1p50_pcap vlan | wc -l) 2>/dev/null
+    pcount52=$(tcpdump -en -r $t2sw1p52_pcap vlan | wc -l) 2>/dev/null
+    pcount_total=$((pcount50 + pcount52))
+    echo $desc pcap count is $pcount6a $pcound6i $pcount50 $pcount52 $pcount_total
+    echo pcap sane $((pcount6a > 10)) $((pcount6i > 10)) $((pcount6a < 180)) \
+         $((pcount_total > 90)) $((pcount_total < 180)) | tee -a $TEST_RESULTS
 
     bcount1e=$(tcpdump -en -r $t1sw1p28_pcap ether broadcast| wc -l) 2>/dev/null
     bcount2e=$(tcpdump -en -r $t1sw2p28_pcap ether broadcast| wc -l) 2>/dev/null
     bcount1h=$(tcpdump -en -r $t2sw1p1_pcap ether broadcast | wc -l) 2>/dev/null
     bcount2h=$(tcpdump -en -r $t2sw2p1_pcap ether broadcast | wc -l) 2>/dev/null
+    echo $desc pcap bcount $bcount1e $bcount2e $bcount1h $bcount2h
     echo pcap bcast $(comp $bcount1e 4) $(comp $bcount2e 0) \
          $(comp $bcount1h 4) $(comp $bcount2h 4) | tee -a $TEST_RESULTS
 

--- a/etc/Dockerfile.controller
+++ b/etc/Dockerfile.controller
@@ -5,14 +5,14 @@ FROM faucet/python3:5.0.1
 RUN apk add -q tcpdump iptables sudo linux-headers
 
 COPY faucet/ /faucet-src/
-COPY . /forch-src/
-
 RUN /faucet-src/docker/install-faucet.sh && rm -rf /faucet-src/.git
-RUN /forch-src/bin/install_forch.sh && rm -rf /forch-src/.git
 
 # Check for target executable since installer doesn't error out properly.
 RUN which faucet
 
 COPY misc/faucet_go bin/
+
+COPY . /forch-src/
+RUN /forch-src/bin/install_forch.sh && rm -rf /forch-src/.git
 
 CMD ["bin/faucet_go"]

--- a/etc/Dockerfile.faucet
+++ b/etc/Dockerfile.faucet
@@ -2,10 +2,9 @@
 
 FROM faucet/python3:5.0.1
 
-RUN apk add -q tcpdump iptables sudo
+RUN apk add -q tcpdump iptables sudo linux-headers
 
 COPY faucet/ /faucet-src/
-
 RUN /faucet-src/docker/install-faucet.sh && rm -rf /faucet-src/.git
 
 # Check for target executable since installer doesn't error out properly.

--- a/etc/docker_images.txt
+++ b/etc/docker_images.txt
@@ -1,4 +1,4 @@
-forch/controller fff6575916fd
-forch/faucet 3aa9c94b8917
-forch/faux aeefa7791437
-forch/gauge 4ebffba285d7
+forch/controller dce940985de0
+forch/faucet bedbb5b880a7
+forch/faux 6982538008c9
+forch/gauge 0c17fa281a48

--- a/etc/test_stack.out
+++ b/etc/test_stack.out
@@ -10,7 +10,7 @@ faucet_config_warning_count 2
 Starting stack-solid test...
 (UNKNOWN) [192.168.1.1] 23 (telnet) : Connection timed out
 (UNKNOWN) [192.168.1.1] 443 (https) : Connection refused
-pcap sane 0 1 1 1
+pcap sane 1 0 1 1 1
 pcap bcast 1 0 1 1
 telnet 1 https 2
 forch-faux-0: ping -c 10 192.168.1.1 10
@@ -126,7 +126,7 @@ process_state{process="sleep"} 0
 Starting stack-linkd test...
 (UNKNOWN) [192.168.1.1] 23 (telnet) : Connection timed out
 (UNKNOWN) [192.168.1.1] 443 (https) : Connection refused
-pcap sane 1 1 1 1
+pcap sane 1 1 1 1 1
 pcap bcast 1 0 1 1
 telnet 1 https 2
 forch-faux-0: ping -c 10 192.168.1.1 10
@@ -146,7 +146,7 @@ Done with stack-linkd test.
 Starting stack-twod test...
 (UNKNOWN) [192.168.1.1] 23 (telnet) : Connection timed out
 (UNKNOWN) [192.168.1.1] 443 (https) : Connection refused
-pcap sane 1 1 1 1
+pcap sane 1 1 1 1 1
 pcap bcast 1 0 1 1
 telnet 1 https 2
 forch-faux-0: ping -c 10 192.168.1.1 10
@@ -214,7 +214,7 @@ null
 Starting stack-broken test...
 (UNKNOWN) [192.168.1.1] 23 (telnet) : Connection timed out
 (UNKNOWN) [192.168.1.1] 443 (https) : Connection timed out
-pcap sane 0 1 0 1
+pcap sane 0 0 1 1 1
 pcap bcast 1 0 1 1
 telnet 0 https 0
 forch-faux-0: ping -c 10 192.168.1.1 0
@@ -279,7 +279,7 @@ null
 Starting stack-restored test...
 (UNKNOWN) [192.168.1.1] 23 (telnet) : Connection timed out
 (UNKNOWN) [192.168.1.1] 443 (https) : Connection refused
-pcap sane 1 1 1 1
+pcap sane 1 1 1 1 1
 pcap bcast 1 0 1 1
 telnet 1 https 2
 forch-faux-0: ping -c 10 192.168.1.1 10


### PR DESCRIPTION
Makes some baseline changes to stack testing in prep for faucet update.  Mosty adds --immediate-mode and vlan filter to tcpdump.
