### PR TITLE
Use print() rather than logger

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -10,6 +10,7 @@ linters:
     ignore:
       - 'W1618'
       - 'W1619'
+      - 'E1601'
 files:
   ignore:
     - 'forch/proto/*'

--- a/testing/python_lib/integration_base.py
+++ b/testing/python_lib/integration_base.py
@@ -7,12 +7,6 @@ import sys
 import time
 import yaml
 
-import logging
-logger = logging.getLogger()
-logger.level = logging.INFO
-stream_handler = logging.StreamHandler(sys.stdout)
-logger.addHandler(stream_handler)
-
 
 class IntegrationTestBase(unittest.TestCase):
     """Base class for integration tests"""
@@ -33,31 +27,30 @@ class IntegrationTestBase(unittest.TestCase):
     def tearDown(self):
         self._clean_stack()
 
-    def _run_command(self, command, strict=True):
-        code, out, err = self._reap_process_command(self._run_process_command(command))
-        if strict and code:
-            logger.warning('stdout: \n' + out)
-            logger.warning('stderr: \n' + err)
-            raise Exception('Command execution failed: %s' % str(command))
-        return code, out, err
-
-    def _run_process_command(self, command):
+    def _run_process_command(self, command, capture):
         command_list = command.split() if isinstance(command, str) else command
-        return subprocess.Popen(command_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        pipeout = subprocess.PIPE if capture else None
+        return subprocess.Popen(command_list, stdout=pipeout, stderr=pipeout)
 
     def _reap_process_command(self, process):
         process.wait()
         stdout, stderr = process.communicate()
-        return process.returncode, str(stdout, 'utf-8'), str(stderr, 'utf-8')
+        strout = str(stdout, 'utf-8') if stdout else None
+        strerr = str(stderr, 'utf-8') if stderr else None
+        return process.returncode, strout, strerr
 
-    def _run_forch_script(self, script, arglist=[]):
-        """Runs scripts from forch base folder"""
-        path = os.path.dirname(os.path.abspath(__file__)) + '/../../'
-        command = [path + script] + arglist
-        return self._run_command(command)
+    def _run_cmd(self, cmd, arglist=None, strict=True, capture=True):
+        command = ([cmd] + arglist) if arglist else cmd
+        retcode, out, err = self._reap_process_command(self._run_process_command(command, capture))
+        if strict and retcode:
+            if capture:
+                print('stdout: \n' + out)
+                print('stderr: \n' + err)
+            raise Exception('Command execution failed: %s' % str(command))
+        return retcode, out, err
 
     def _setup_stack(self, options=STACK_OPTIONS):
-        logger.debug("STACK_OPTIONS = %s", str(options))
+        print("STACK_OPTIONS = %s", str(options))
         stack_args = []
         stack_args.extend(['local'] if options.get('local') else [])
         devices = options.get('devices')
@@ -70,41 +63,41 @@ class IntegrationTestBase(unittest.TestCase):
         mode = options.get('mode')
         stack_args.extend([mode] if mode else [])
 
-        logger.info('setup_stack ' + ' '.join(stack_args))
-        code, out, err = self._run_forch_script('bin/setup_stack', stack_args)
-        if code:
-            logger.info('setup_stack stdout: \n' + out)
-            logger.info('setup_stack stderr: \n' + err)
-            assert False, 'setup_stack failed'
-
-        time.sleep(options.get('setup_warmup_sec'))
+        print('setup_stack ' + ' '.join(stack_args))
+        self._run_cmd('bin/setup_stack', stack_args)
+        setup_warmup_sec = options.get('setup_warmup_sec')
+        print('waiting %s...' % setup_warmup_sec)
+        time.sleep(setup_warmup_sec)
 
     def _clean_stack(self):
-        code, out, err = self._run_forch_script('bin/net_clean')
-        logger.debug('clean stack stdout: \n' + out)
-        logger.debug('clean stack stderr: \n' + err)
+        self._run_cmd('bin/net_clean')
 
-    def _ping_host(self, *args, **kwargs):
-        return self._ping_host_reap(self._ping_host_process(*args, **kwargs))
+    def _ping_host(self, container, host, count=1, output=False):
+        return self._ping_host_reap(
+            self._ping_host_process(container, host, count=count),
+            output=output)
 
     def _ping_host_process(self, container, host, count=1):
-        logger.debug('Trying to ping %s from %s' % (host, container))
+        print('ping %s from %s' % (host, container))
+        self._run_cmd('date -u', capture=False)
         ping_cmd = 'docker exec %s ping -c %d %s' % (container, count, host)
-        return self._run_process_command(ping_cmd)
+        return self._run_process_command(ping_cmd, True)
 
-    def _ping_host_reap(self, process, expected=False):
+    def _ping_host_reap(self, process, expected=False, output=False):
         return_code, out, err = self._reap_process_command(process)
         unexpected = not expected if return_code else expected
-        if unexpected:
-            logger.warning('ping with %s', str(process.args))
-            logger.warning(out)
-            logger.warning('Ping return code: %s\nstderr: %s', return_code, err)
-        return False if return_code else out.count('icmp_seq')
+        if unexpected or output:
+            print('ping with %s' % str(process.args))
+            print(out)
+            print('Ping return code: %d' % return_code)
+            print('stderr: %s' % err)
+        return False if return_code else out.count('time=')
 
     def _fail_egress_link(self, alternate=False, restore=False):
         switch = 't1sw2' if alternate else 't1sw1'
         command = 'up' if restore else 'down'
-        self._run_command('sudo ip link set %s-eth28 %s' % (switch, command))
+        self._run_cmd('sudo ip link set %s-eth28 %s' % (switch, command),
+                      capture=False)
 
     def _read_yaml_from_file(self, filename):
         with open(filename) as config_file:

--- a/testing/python_lib/test_failscale.py
+++ b/testing/python_lib/test_failscale.py
@@ -19,13 +19,13 @@ class FailScaleConfigTest(IntegrationTestBase):
 
     def test_stack_connectivity(self):
         """Test to build stack and check for connectivity"""
-        self.assertEqual(10, self._ping_host('forch-faux-8', '192.168.1.0', count=10),
+        self.assertEqual(10, self._ping_host('forch-faux-8', '192.168.1.0', count=10, output=True),
                          'warm-up ping count')
-        process = self._ping_host_process('forch-faux-8', '192.168.1.0', count=40)
+        process = self._ping_host_process('forch-faux-8', '192.168.1.0', count=60)
         time.sleep(5)
         self._fail_egress_link()
-        ping_count = self._ping_host_reap(process)
-        self.assertTrue(ping_count > 15 and ping_count < 35, 'disrupted ping count %s' % ping_count)
+        ping_count = self._ping_host_reap(process, output=True)
+        self.assertTrue(ping_count > 25 and ping_count < 55, 'disrupted ping count %s' % ping_count)
 
 
 if __name__ == '__main__':

--- a/testing/python_lib/test_fot.py
+++ b/testing/python_lib/test_fot.py
@@ -11,7 +11,7 @@ from forch.proto.devices_state_pb2 import DeviceBehavior
 from forch.proto.device_testing_state_pb2 import DeviceTestingState
 from forch.proto.shared_constants_pb2 import Empty
 
-from integration_base import IntegrationTestBase, logger
+from integration_base import IntegrationTestBase
 from unit_base import (
     DeviceTestingServerTestBase, FaucetizerTestBase, PortsStateManagerTestBase
 )
@@ -25,7 +25,7 @@ class FotConfigTest(IntegrationTestBase):
 
     def test_stack_connectivity(self):
         """Test to build stack and check for connectivity"""
-        logger.debug('Running test_stack_connectivity')
+        print('Running test_stack_connectivity')
         self.assertTrue(self._ping_host('forch-faux-1', '192.168.1.2'))
         self.assertFalse(self._ping_host('forch-faux-1', '192.168.1.12'))
 
@@ -124,7 +124,7 @@ class FotDeviceTestingServerTestCase(DeviceTestingServerTestBase):
 
         future_responses = []
         for testing_state in expected_testing_states:
-            logger.info('Sending device testing state: %s', testing_state)
+            print('Sending device testing state: %s', testing_state)
             future_response = self._client.ReportTestingState.future(
                 dict_proto(testing_state, DeviceTestingState))
             future_responses.append(future_response)
@@ -145,7 +145,7 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
         super().__init__(*args, **kwargs)
 
     def _process_device_behavior(self, mac, device_behavior, static=False):
-        logger.info(
+        print(
             'Received device behavior for device %s: %s, %s', mac, device_behavior, static)
         self._received_device_behaviors.append((mac, device_behavior.segment, static))
 


### PR DESCRIPTION
Something is wonky with the python logger and the unit tests... it will deadlock sometimes when there's a lot of output. This just uses the print() method instead and makes the logs somewhat more verbose.