### PR TITLE
Do not raise exception in case of out-of-sequence Faucet event

### DIFF
--- a/forch/faucet_event_client.py
+++ b/forch/faucet_event_client.py
@@ -115,7 +115,9 @@ class FaucetEventClient():
             return False
         self._last_event_id += 1
         if event_id != self._last_event_id:
-            raise Exception('Out-of-sequence event id #%d' % event_id)
+            LOGGER.error(
+                'Out-of-sequence event id. Last: %d, received: %d' % self._last_event_id, event_id)
+            self._last_event_id = event_id + 1
         return True
 
     def _handle_port_change_debounce(self, event, target_event):

--- a/forch/faucet_event_client.py
+++ b/forch/faucet_event_client.py
@@ -118,7 +118,8 @@ class FaucetEventClient():
         if event_id != self._last_event_id:
             LOGGER.error(
                 'Out-of-sequence event id. Last: %d, received: %d' % self._last_event_id, event_id)
-            self._metrics.inc_var('faucet_event_out_of_sequence_count')
+            if self._forch_metrics:
+                self._forch_metrics.inc_var('faucet_event_out_of_sequence_count')
             self._last_event_id = event_id + 1
         return True
 

--- a/forch/faucet_event_client.py
+++ b/forch/faucet_event_client.py
@@ -22,7 +22,7 @@ class FaucetEventClient():
     FAUCET_RETRIES = 10
     _PORT_DEBOUNCE_SEC = 5
 
-    def __init__(self, config):
+    def __init__(self, config, forch_metrics):
         self.config = config
         self.sock = None
         self.buffer = None
@@ -33,6 +33,7 @@ class FaucetEventClient():
         self._port_timers = {}
         self.event_socket_connected = False
         self._last_event_id = None
+        self._forch_metrics = forch_metrics
 
     def connect(self):
         """Make connection to sock to receive events"""
@@ -117,6 +118,7 @@ class FaucetEventClient():
         if event_id != self._last_event_id:
             LOGGER.error(
                 'Out-of-sequence event id. Last: %d, received: %d' % self._last_event_id, event_id)
+            self._metrics.inc_var('faucet_event_out_of_sequence_count')
             self._last_event_id = event_id + 1
         return True
 

--- a/forch/forch_metrics.py
+++ b/forch/forch_metrics.py
@@ -94,6 +94,10 @@ class ForchMetrics():
         self._add_var(
             'faucet_config_warning', 'Faucet configuration warning', Gauge, ['key', 'message'])
 
+        self._add_var(
+            'faucet_event_out_of_sequence_count',
+            'Number of times Faucet event becomes out of sequence', Counter)
+
     def get_metrics(self, path, params):
         """Return metric list in printable form"""
         return generate_latest(self._reg).decode('utf-8')

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -24,7 +24,8 @@ from forch.heartbeat_scheduler import HeartbeatScheduler
 from forch.local_state_collector import LocalStateCollector
 from forch.port_state_manager import PortStateManager
 import forch.varz_state_collector as varz_state_collector
-from forch.utils import get_logger, proto_dict, yaml_proto, FaucetEventOrderError, FaucetVarzError
+from forch.utils import (
+    get_logger, proto_dict, yaml_proto, FaucetEventOrderError, VarzFetchingError)
 
 from forch.__version__ import __version__
 
@@ -175,7 +176,7 @@ class Forchestrator:
                 varz_retry -= 1
 
         if varz_retry == 0:
-            raise FaucetVarzError('Could not get Faucet varz')
+            raise VarzFetchingError('Could not get Faucet varz')
 
         self._register_handlers()
         self.start()

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -164,13 +164,17 @@ class Forchestrator:
 
         self._validate_config_files()
 
-        while True:
+        varz_retry = 10
+        while varz_retry > 0:
             time.sleep(10)
             try:
                 self._get_varz_config()
                 break
             except Exception as e:
                 LOGGER.error('Waiting for varz config: %s', e)
+                varz_retry -= 1
+
+        assert varz_retry > 0, 'Could not get Faucet varz'
 
         self._register_handlers()
         self.start()

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -153,7 +153,7 @@ class Forchestrator:
 
         LOGGER.info('Attaching event channel...')
         self._faucet_events = forch.faucet_event_client.FaucetEventClient(
-            self._config.event_client)
+            self._config.event_client, self._metrics)
         self._local_collector.initialize()
         self._cpn_collector.initialize()
         LOGGER.info('Using peer controller %s', self._get_peer_controller_url())

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -153,7 +153,7 @@ class Forchestrator:
 
         LOGGER.info('Attaching event channel...')
         self._faucet_events = forch.faucet_event_client.FaucetEventClient(
-            self._config.event_client, self._metrics)
+            self._config.event_client)
         self._local_collector.initialize()
         self._cpn_collector.initialize()
         LOGGER.info('Using peer controller %s', self._get_peer_controller_url())

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -24,7 +24,7 @@ from forch.heartbeat_scheduler import HeartbeatScheduler
 from forch.local_state_collector import LocalStateCollector
 from forch.port_state_manager import PortStateManager
 import forch.varz_state_collector as varz_state_collector
-from forch.utils import get_logger, proto_dict, yaml_proto, FaucetEventOrderError
+from forch.utils import get_logger, proto_dict, yaml_proto, FaucetEventOrderError, FaucetVarzError
 
 from forch.__version__ import __version__
 
@@ -174,7 +174,8 @@ class Forchestrator:
                 LOGGER.error('Waiting for varz config: %s', e)
                 varz_retry -= 1
 
-        assert varz_retry > 0, 'Could not get Faucet varz'
+        if varz_retry == 0:
+            raise FaucetVarzError('Could not get Faucet varz')
 
         self._register_handlers()
         self.start()

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -25,7 +25,7 @@ from forch.local_state_collector import LocalStateCollector
 from forch.port_state_manager import PortStateManager
 import forch.varz_state_collector as varz_state_collector
 from forch.utils import (
-    get_logger, proto_dict, yaml_proto, FaucetEventOrderError, VarzFetchingError)
+    get_logger, proto_dict, yaml_proto, FaucetEventOrderError, MetricsFetchingError)
 
 from forch.__version__ import __version__
 
@@ -176,7 +176,7 @@ class Forchestrator:
                 varz_retry -= 1
 
         if varz_retry == 0:
-            raise VarzFetchingError('Could not get Faucet varz')
+            raise MetricsFetchingError('Could not get Faucet varz metrics')
 
         self._register_handlers()
         self.start()

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -24,7 +24,7 @@ from forch.heartbeat_scheduler import HeartbeatScheduler
 from forch.local_state_collector import LocalStateCollector
 from forch.port_state_manager import PortStateManager
 import forch.varz_state_collector as varz_state_collector
-from forch.utils import get_logger, proto_dict, yaml_proto
+from forch.utils import get_logger, proto_dict, yaml_proto, FaucetEventOrderError
 
 from forch.__version__ import __version__
 
@@ -446,7 +446,14 @@ class Forchestrator:
             while self._faucet_events:
                 while not self._faucet_events.event_socket_connected:
                     self._faucet_events_connect()
-                self._faucet_events.next_event(blocking=True)
+
+                try:
+                    self._faucet_events.next_event(blocking=True)
+                except FaucetEventOrderError as e:
+                    LOGGER.error("Faucet event order error: %s", e)
+                    if self._metrics:
+                        self._metrics.inc_var('faucet_event_out_of_sequence_count')
+                    self._restore_states()
         except KeyboardInterrupt:
             LOGGER.info('Keyboard interrupt. Exiting.')
             self._faucet_events.disconnect()

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -23,8 +23,8 @@ class FaucetEventOrderError(Exception):
     """Error for when Faucet event is out of sequence"""
 
 
-class FaucetVarzError(Exception):
-    """Failure of fetching Faucet varz"""
+class VarzFetchingError(Exception):
+    """Failure of fetching varzs"""
 
 
 def _get_log_path():

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -19,6 +19,10 @@ class ConfigError(Exception):
     """Error for when config isn't valid."""
 
 
+class FaucetEventOrderError(Exception):
+    """Error for when Faucet event is out of sequence"""
+
+
 def _get_log_path():
     """Get path for logging"""
     forch_log_dir = os.getenv('FORCH_LOG_DIR')

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -24,7 +24,7 @@ class FaucetEventOrderError(Exception):
 
 
 class MetricsFetchingError(Exception):
-    """Failure of fetching varzs"""
+    """Failure of fetching target metrics"""
 
 
 def _get_log_path():

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -23,6 +23,10 @@ class FaucetEventOrderError(Exception):
     """Error for when Faucet event is out of sequence"""
 
 
+class FaucetVarzError(Exception):
+    """Failure of fetching Faucet varz"""
+
+
 def _get_log_path():
     """Get path for logging"""
     forch_log_dir = os.getenv('FORCH_LOG_DIR')

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -23,7 +23,7 @@ class FaucetEventOrderError(Exception):
     """Error for when Faucet event is out of sequence"""
 
 
-class VarzFetchingError(Exception):
+class MetricsFetchingError(Exception):
     """Failure of fetching varzs"""
 
 

--- a/forch/varz_state_collector.py
+++ b/forch/varz_state_collector.py
@@ -5,7 +5,7 @@ import time
 import prometheus_client.parser
 import requests
 
-from forch.utils import get_logger
+from forch.utils import get_logger, MetricsFetchingError
 
 LOGGER = get_logger('vstate')
 
@@ -37,4 +37,4 @@ def retry_get_metrics(endpoint, target_metrics, retries=3):
         except Exception as e:
             LOGGER.warning("Cannot retrieve prometheus metrics: %s, retry: %d", e, retry)
             time.sleep(1)
-    raise Exception(f"Cannot retrieve prometheus metrics after {retries} retries")
+    raise MetricsFetchingError(f"Cannot retrieve prometheus metrics after {retries} retries")

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -1,0 +1,50 @@
+"""Faucet event tests"""
+
+import functools
+import json
+import os
+import socket
+import threading
+import unittest
+
+from unit_base import ForchestratorTestBase
+
+
+class FaucetEventOrderTestCase(ForchestratorTestBase):
+    """Faucet event order test case"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lock = threading.Lock()
+        self._event_server_thread = None
+        self._forchestrator_thread = None
+        self._event_server_connection = None
+
+    def _handle_connection(self, event_socket):
+        event_socket.listen(1)
+        while True:
+            print('Waiting for incoming connection')
+            self._connection, _ = event_socket.accept()
+
+    def _setup_event_server(self):
+        assert self._temp_socket_file
+        event_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        event_socket.bind(self._temp_socket_file)
+        handle_connection = functools.partial(self._handle_connection, event_socket)
+        self._event_server_thread = threading.Thread(target=handle_connection, daemon=True)
+
+    def setUp(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._setup_event_server()
+
+    def test_out_of_sequence(self):
+        events = [
+            {'version': 1, 'time': 123.0, 'event_id': 101},
+            {'version': 1, 'time': 124.0, 'event_id': 200},
+        ]
+        for event in events:
+            event_bytes = bytes('\n'.join((json.dumps(event, default=str), '')).encode('UTF-8'))
+            self._event_server_connection.sendall(event_bytes)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -67,6 +67,9 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
         try:
             self._forchestrator.main_loop()
         except InvalidConfigError as error:
+            # Forchestrator.restore_states() will raise InvalidConfigError as the config file is
+            # actually empty. In the other words, if this error is raised, it implies
+            # restore_states() is called.
             print(f'Expected error during restoring states: {error}')
             restore_states_called = True
 

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -8,6 +8,7 @@ import threading
 import unittest
 
 from faucet.conf import InvalidConfigError
+from forch.utils import FaucetVarzError
 
 from unit_base import ForchestratorTestBase
 
@@ -48,7 +49,10 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
     # pylint: disable=invalid-name
     def setUp(self, *args, **kwargs):
         """Set up env and event server"""
-        super().setUp(*args, **kwargs)
+        try:
+            super().setUp(*args, **kwargs)
+        except FaucetVarzError as error:
+            print(f'Expected error during Forchestrator initialization: %s', error)
         os.environ['FAUCET_EVENT_DEBUG'] = '1'
         self._setup_event_server()
 

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -51,7 +51,7 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
         try:
             super().setUp(*args, **kwargs)
         except MetricsFetchingError as error:
-            print(f'Expected error during Forchestrator initialization: %s', error)
+            print(f'Expected error during Forchestrator initialization: {error}')
         os.environ['FAUCET_EVENT_DEBUG'] = '1'
         self._setup_event_server()
 

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -59,7 +59,7 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
             print(f'Ignoring expected exception during restoring states: {error}')
 
         self._forchestrator._faucet_events.set_event_horizon(100)
-        restore_states_called= False
+        restore_states_called = False
 
         try:
             self._forchestrator.main_loop()

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -19,7 +19,6 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
         super().__init__(*args, **kwargs)
         self._lock = threading.Lock()
         self._event_server_thread = None
-        self._forchestrator_thread = None
 
     def _handle_connection(self, event_socket):
         event_socket.listen(1)

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -7,7 +7,7 @@ import socket
 import threading
 import unittest
 
-from forch.utils import VarzFetchingError
+from forch.utils import MetricsFetchingError
 
 from unit_base import ForchestratorTestBase
 
@@ -50,7 +50,7 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
         """Set up env and event server"""
         try:
             super().setUp(*args, **kwargs)
-        except VarzFetchingError as error:
+        except MetricsFetchingError as error:
             print(f'Expected error during Forchestrator initialization: %s', error)
         os.environ['FAUCET_EVENT_DEBUG'] = '1'
         self._setup_event_server()
@@ -64,7 +64,7 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
 
         try:
             self._forchestrator.main_loop()
-        except VarzFetchingError as error:
+        except MetricsFetchingError as error:
             # Forchestrator.restore_states() will raise VarzFetchingError as Faucet prometheus
             # client is not enabled, and thus this error implies restore_states() is called.
             print(f'Expected error during restoring states: {error}')

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -46,11 +46,14 @@ class FaucetEventOrderTestCase(ForchestratorTestBase):
         self._event_server_thread = threading.Thread(target=handle_connection, daemon=True)
         self._event_server_thread.start()
 
+    # pylint: disable=invalid-name
     def setUp(self, *args, **kwargs):
+        """Set up env and event server"""
         super().setUp(*args, **kwargs)
         os.environ['FAUCET_EVENT_DEBUG'] = '1'
         self._setup_event_server()
 
+    # pylint: disable=protected-access
     def test_out_of_sequence(self):
         """Test Forch behavior in case of out-of-sequence event"""
         try:

--- a/testing/python_lib/test_event.py
+++ b/testing/python_lib/test_event.py
@@ -7,7 +7,6 @@ import socket
 import threading
 import unittest
 
-from faucet.conf import InvalidConfigError
 from forch.utils import VarzFetchingError
 
 from unit_base import ForchestratorTestBase

--- a/testing/python_lib/unit_base.py
+++ b/testing/python_lib/unit_base.py
@@ -66,16 +66,20 @@ class ForchestratorTestBase(UnitTestBase):
 
     def _setup_env(self):
         assert self._temp_dir
-        os.environ["FORCH_CONFIG_DIR"] = self._temp_dir
-        os.environ["FORCH_CONFIG_FILE"] = os.path.basename(self._temp_forch_config_file)
-        os.environ["FAUCET_CONFIG_DIR"] = self._temp_dir
-        os.environ["FAUCET_CONFIG_FILE"] = os.path.basename(self._temp_behavioral_config_file)
-        os.environ["FAUCET_EVENT_SOCK"] = self._temp_socket_file
+        os.environ['FORCH_CONFIG_DIR'] = self._temp_dir
+        os.environ['FORCH_CONFIG_FILE'] = os.path.basename(self._temp_forch_config_file)
+        os.environ['FAUCET_CONFIG_DIR'] = self._temp_dir
+        os.environ['FAUCET_CONFIG_FILE'] = os.path.basename(self._temp_behavioral_config_file)
+        os.environ['FAUCET_EVENT_SOCK'] = self._temp_socket_file
+        os.environ['CONTROLLER_NAME'] = 'ctr1'
 
     def _initialize_forchestrator(self):
         forch_config = dict_proto(yaml.safe_load(self.FORCH_CONFIG), ForchConfig)
         self._forchestrator = Forchestrator(forch_config)
-        self._forchestrator.initialize()
+        try:
+            self._forchestrator.initialize()
+        except ConnectionRefusedError:
+            print('Ignoring connection error during Forchestrator initialization')
 
     def setUp(self):
         """setup fixture for each test method"""

--- a/testing/python_lib/unit_base.py
+++ b/testing/python_lib/unit_base.py
@@ -8,9 +8,11 @@ import yaml
 
 import grpc
 
+from forch.__main__ import load_config
 from forch.device_testing_server import DeviceTestingServer
 from forch.faucetizer import Faucetizer
 from forch.faucet_state_collector import FaucetStateCollector
+from forch.forchestrator import Forchestrator
 from forch.port_state_manager import PortStateManager
 from forch.utils import dict_proto
 
@@ -32,12 +34,14 @@ class UnitTestBase(unittest.TestCase):
         self._temp_structural_config_file = None
         self._temp_behavioral_config_file = None
         self._temp_forch_config_file = None
+        self._temp_socket_file = None
 
     def _setup_config_files(self):
         self._temp_dir = tempfile.mkdtemp()
         _, self._temp_structural_config_file = tempfile.mkstemp(dir=self._temp_dir)
         _, self._temp_behavioral_config_file = tempfile.mkstemp(dir=self._temp_dir)
         _, self._temp_forch_config_file = tempfile.mkstemp(dir=self._temp_dir)
+        self._temp_socket_file = os.path.join(self._temp_dir, 'faucet_event.sock')
 
         with open(self._temp_structural_config_file, 'w') as structural_config_file:
             structural_config_file.write(self.FAUCET_STRUCTURAL_CONFIG)
@@ -52,13 +56,31 @@ class UnitTestBase(unittest.TestCase):
 class ForchestratorTestBase(UnitTestBase):
     """Base class for Forchestrator unit tests"""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._forchestrator = None
+
     def _setup_env(self):
+        assert self._temp_dir
         os.environ["FORCH_CONFIG_DIR"] = self._temp_dir
-        os.environ["FORCH_CONFIG_DIR"] = os.path.basename(self._temp_forch_config_file)
+        os.environ["FORCH_CONFIG_FILE"] = os.path.basename(self._temp_forch_config_file)
         os.environ["FAUCET_CONFIG_DIR"] = self._temp_dir
         os.environ["FAUCET_CONFIG_FILE"] = os.path.basename(self._temp_behavioral_config_file)
+        os.environ["FAUCET_EVENT_SOCK"] = self._temp_socket_file
 
+    def _initialize_forchestrator(self):
+        config = load_config()
+        self._forchestrator = Forchestrator(config)
 
+    def setUp(self):
+        """setup fixture for each test method"""
+        self._setup_config_files()
+        self._setup_env()
+        self._initialize_forchestrator()
+
+    def tearDown(self):
+        """cleanup after each test method finishes"""
+        self._cleanup_config_files()
 
 
 class FaucetizerTestBase(UnitTestBase):

--- a/testing/python_lib/unit_base.py
+++ b/testing/python_lib/unit_base.py
@@ -8,7 +8,6 @@ import yaml
 
 import grpc
 
-from forch.__main__ import load_config
 from forch.device_testing_server import DeviceTestingServer
 from forch.faucetizer import Faucetizer
 from forch.faucet_state_collector import FaucetStateCollector
@@ -56,6 +55,11 @@ class UnitTestBase(unittest.TestCase):
 class ForchestratorTestBase(UnitTestBase):
     """Base class for Forchestrator unit tests"""
 
+    FORCH_CONFIG = """
+    site:
+      name: nz-kiwi
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._forchestrator = None
@@ -69,8 +73,9 @@ class ForchestratorTestBase(UnitTestBase):
         os.environ["FAUCET_EVENT_SOCK"] = self._temp_socket_file
 
     def _initialize_forchestrator(self):
-        config = load_config()
-        self._forchestrator = Forchestrator(config)
+        forch_config = dict_proto(yaml.safe_load(self.FORCH_CONFIG), ForchConfig)
+        self._forchestrator = Forchestrator(forch_config)
+        self._forchestrator.initialize()
 
     def setUp(self):
         """setup fixture for each test method"""

--- a/testing/python_lib/unit_base.py
+++ b/testing/python_lib/unit_base.py
@@ -58,6 +58,8 @@ class ForchestratorTestBase(UnitTestBase):
     FORCH_CONFIG = """
     site:
       name: nz-kiwi
+    varz_interface:
+      varz_port: 60000
     """
 
     def __init__(self, *args, **kwargs):

--- a/testing/python_lib/unit_base.py
+++ b/testing/python_lib/unit_base.py
@@ -1,5 +1,6 @@
 """Unit test base class for Forch"""
 
+import os
 import shutil
 import tempfile
 import unittest
@@ -30,17 +31,34 @@ class UnitTestBase(unittest.TestCase):
         self._temp_dir = None
         self._temp_structural_config_file = None
         self._temp_behavioral_config_file = None
+        self._temp_forch_config_file = None
 
     def _setup_config_files(self):
         self._temp_dir = tempfile.mkdtemp()
         _, self._temp_structural_config_file = tempfile.mkstemp(dir=self._temp_dir)
         _, self._temp_behavioral_config_file = tempfile.mkstemp(dir=self._temp_dir)
+        _, self._temp_forch_config_file = tempfile.mkstemp(dir=self._temp_dir)
 
         with open(self._temp_structural_config_file, 'w') as structural_config_file:
             structural_config_file.write(self.FAUCET_STRUCTURAL_CONFIG)
 
+        with open(self._temp_forch_config_file, 'w') as forch_config_file:
+            forch_config_file.write(self.FORCH_CONFIG)
+
     def _cleanup_config_files(self):
         shutil.rmtree(self._temp_dir)
+
+
+class ForchestratorTestBase(UnitTestBase):
+    """Base class for Forchestrator unit tests"""
+
+    def _setup_env(self):
+        os.environ["FORCH_CONFIG_DIR"] = self._temp_dir
+        os.environ["FORCH_CONFIG_DIR"] = os.path.basename(self._temp_forch_config_file)
+        os.environ["FAUCET_CONFIG_DIR"] = self._temp_dir
+        os.environ["FAUCET_CONFIG_FILE"] = os.path.basename(self._temp_behavioral_config_file)
+
+
 
 
 class FaucetizerTestBase(UnitTestBase):

--- a/testing/test_base
+++ b/testing/test_base
@@ -13,3 +13,4 @@ testing/test_solo
 testing/test_counting
 testing/python_test coverage test_faucetizer
 testing/python_test coverage test_faucet_state_collector
+testing/python_test coverage test_event


### PR DESCRIPTION
Every time Forch connects to the socket it will restore the states from varzs. So I think we can remove the exception here.