### PR TITLE
Preserve directory path of included file in Faucet config

### DIFF
--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import yaml
 
-from forch.utils import get_logger, yaml_proto
+from forch.utils import get_logger, safe_mkdir, yaml_proto
 
 from forch.proto.devices_state_pb2 import DevicesState, SegmentsToVlans
 from forch.proto.devices_state_pb2 import DevicePlacement, DeviceBehavior
@@ -348,7 +348,7 @@ class Faucetizer:
             acls_config = include_config.get('acls')
             self._augment_acls_config(acls_config, file_path)
 
-            new_file_name = self._augment_include_file_name(os.path.split(file_path)[1])
+            new_file_name = self._augment_include_file_name(file_path)
             self.flush_include_config(new_file_name, include_config)
 
     def reload_segments_to_vlans(self, file_path):
@@ -386,6 +386,7 @@ class Faucetizer:
     def flush_include_config(self, include_file_name, include_config):
         """Write include configs to file"""
         faucet_include_file_path = os.path.join(self._faucet_config_dir, include_file_name)
+        safe_mkdir(os.path.dirname(faucet_include_file_path))
         with open(faucet_include_file_path, 'w') as file:
             yaml.dump(include_config, file)
             LOGGER.debug('Wrote augmented included file to %s', faucet_include_file_path)

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -348,8 +348,9 @@ class Faucetizer:
             acls_config = include_config.get('acls')
             self._augment_acls_config(acls_config, file_path)
 
-            new_file_name = self._augment_include_file_name(file_path)
-            self.flush_include_config(new_file_name, include_config)
+            relative_include_path = os.path.relpath(file_path, start=self._forch_config_dir)
+            new_file_path = self._augment_include_file_name(relative_include_path)
+            self.flush_include_config(new_file_path, include_config)
 
     def reload_segments_to_vlans(self, file_path):
         """Reload file that contains the mappings from segments to vlans"""

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import yaml
 
-from forch.utils import get_logger, safe_mkdir, yaml_proto
+from forch.utils import get_logger, yaml_proto
 
 from forch.proto.devices_state_pb2 import DevicesState, SegmentsToVlans
 from forch.proto.devices_state_pb2 import DevicePlacement, DeviceBehavior
@@ -386,7 +386,7 @@ class Faucetizer:
     def flush_include_config(self, include_file_name, include_config):
         """Write include configs to file"""
         faucet_include_file_path = os.path.join(self._faucet_config_dir, include_file_name)
-        safe_mkdir(os.path.dirname(faucet_include_file_path))
+        os.makedirs(os.path.dirname(faucet_include_file_path), exist_ok=True)
         with open(faucet_include_file_path, 'w') as file:
             yaml.dump(include_config, file)
             LOGGER.debug('Wrote augmented included file to %s', faucet_include_file_path)

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -93,6 +93,7 @@ def str_proto(message_text, proto_func):
 
 
 def safe_mkdir(path):
+    """Create directory if not exists"""
     try:
         os.makedirs(path)
     except OSError as error:

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -1,6 +1,5 @@
 """Utility functions for forch"""
 
-import errno
 import logging
 import os
 import yaml
@@ -90,13 +89,3 @@ def dict_proto(message, proto_func, ignore_unknown_fields=False):
 def str_proto(message_text, proto_func):
     """Convert a string represented protobuf message to proto object"""
     return text_format.Parse(message_text, proto_func())
-
-
-def safe_mkdir(path):
-    """Create directory if not exists"""
-    try:
-        os.makedirs(path)
-    except OSError as error:
-        if error.errno == errno.EEXIST and os.path.isdir(path):
-            return
-        raise Exception('Cannot create director %s: %s' % (path, error))

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for forch"""
 
+import errno
 import logging
 import os
 import yaml
@@ -89,3 +90,12 @@ def dict_proto(message, proto_func, ignore_unknown_fields=False):
 def str_proto(message_text, proto_func):
     """Convert a string represented protobuf message to proto object"""
     return text_format.Parse(message_text, proto_func())
+
+
+def safe_mkdir(path):
+    try:
+        os.makedirs(path)
+    except OSError as error:
+        if error.errno == errno.EEXIST and os.path.isdir(path):
+            return
+        raise Exception('Cannot create director %s: %s' % (path, error))


### PR DESCRIPTION
For example, if the included file is `foo/bar/uniform.yaml`, with this PR, Forch will write it to `/etc/faucet/foo/bar/uniform.yaml`. Currently the output path is `/etc/faucet/uniform.yaml`.