### PR TITLE
Get dpid from wrapping event for port state handling

### DIFF
--- a/bin/stack_functions
+++ b/bin/stack_functions
@@ -349,6 +349,7 @@ function test_forch {
     fetch_forch switch_state '?switch=nz-kiwi-t2sw1&port=1' 1
     fetch_forch switch_state '?switch=nz-kiwi-t1sw2&port=10' 2
     fetch_forch switch_state '?switch=nz-kiwi-t2sw3&port=1' 3
+    fetch_forch switch_state '?switch=nz-kiwi-t1sw2&port=6' 4
     fetch_forch cpn_state
     fetch_forch process_state
     fetch_forch list_hosts '' 1
@@ -388,6 +389,8 @@ function test_forch {
     jq '.switches."nz-kiwi-t2sw2".ports."46".attributes.description' $api_result | tee -a $TEST_RESULTS
     api_result=$fout_dir/switch_state3.json
     dq '.switches."nz-kiwi-t2sw3".switch_state_change_count' $api_result $TEST_RESULTS
+    api_result=$fout_dir/switch_state4.json
+    jq '.switches."nz-kiwi-t1sw2".ports."6".port_state' $api_result | tee -a $TEST_RESULTS
 
     echo @cpn_state$fdesc | tee -a $TEST_RESULTS
     api_result=$fout_dir/cpn_state.json

--- a/etc/test_stack.out
+++ b/etc/test_stack.out
@@ -49,6 +49,7 @@ Running forch-solid tests
 "active"
 null
 3
+"up"
 @cpn_state-solid
 3
 "127.0.0.1"
@@ -95,6 +96,7 @@ Running forch-healthy tests
 "active"
 null
 0
+"up"
 @cpn_state-healthy
 1
 "127.0.0.1"
@@ -187,6 +189,7 @@ Running forch-twod tests
 "active"
 null
 1
+"up"
 @cpn_state-twod
 0
 "127.0.0.1"
@@ -255,6 +258,7 @@ null
 "active"
 null
 3
+"down"
 @cpn_state-broken
 0
 "127.0.0.1"
@@ -320,6 +324,7 @@ Running forch-restored tests
 "active"
 null
 2
+"up"
 @cpn_state-restored
 0
 "127.0.0.1"
@@ -385,6 +390,7 @@ Running forch-orphaned tests
 "active"
 null
 4
+"down"
 @cpn_state-orphaned
 1
 "127.0.0.1"
@@ -431,6 +437,7 @@ Running forch-reset tests
 "active"
 null
 4
+"up"
 @cpn_state-reset
 0
 "127.0.0.1"
@@ -477,6 +484,7 @@ Running forch-restart tests
 "active"
 null
 1
+"up"
 @cpn_state-restart
 3
 "127.0.0.1"

--- a/forch/faucet_event_client.py
+++ b/forch/faucet_event_client.py
@@ -143,6 +143,7 @@ class FaucetEventClient():
         state_key = '%s-%d' % (dpid, port)
         if state_key in self.previous_state and self.previous_state[state_key] == active:
             return False
+        LOGGER.debug('Port change %s active %s', state_key, active)
         self.previous_state[state_key] = active
         return True
 

--- a/forch/faucet_event_client.py
+++ b/forch/faucet_event_client.py
@@ -120,7 +120,7 @@ class FaucetEventClient():
 
     def _handle_port_change_debounce(self, event, target_event):
         if isinstance(target_event, PortChange):
-            dpid = target_event.dp_id
+            dpid = event['dp_id']
             port = target_event.port_no
             active = target_event.status and target_event.reason != 'DELETE'
             if not event.get('debounced'):
@@ -143,7 +143,6 @@ class FaucetEventClient():
         state_key = '%s-%d' % (dpid, port)
         if state_key in self.previous_state and self.previous_state[state_key] == active:
             return False
-        LOGGER.debug('Port change %s active %s', state_key, active)
         self.previous_state[state_key] = active
         return True
 


### PR DESCRIPTION
Fixing the problem that inner PORT_CHANGE event does not have a dp_id info.