### PR TITLE
Avoid reaptedly adding log handlers

### DIFF
--- a/forch/__main__.py
+++ b/forch/__main__.py
@@ -40,6 +40,7 @@ def show_error(error, path, params):
 def run_forchestrator():
     """main function to start forch"""
     logger = get_logger(_LOGGER_NAME)
+    logger.info('Starting Forchestrator')
 
     config = load_config()
     if not config:

--- a/forch/__main__.py
+++ b/forch/__main__.py
@@ -14,20 +14,21 @@ from forch.utils import get_logger, yaml_proto
 from forch.__version__ import __version__
 
 _FORCH_CONFIG_DEFAULT = 'forch.yaml'
-
-LOGGER = get_logger('main')
+_LOGGER_NAME = 'main'
 
 
 def load_config():
     """Load configuration from the configuration file"""
+    logger = get_logger(_LOGGER_NAME)
+
     config_root = os.getenv('FORCH_CONFIG_DIR', '.')
     config_file = os.getenv('FORCH_CONFIG_FILE', _FORCH_CONFIG_DEFAULT)
     config_path = os.path.join(config_root, config_file)
-    LOGGER.info('Reading config file %s', os.path.abspath(config_path))
+    logger.info('Reading config file %s', os.path.abspath(config_path))
     try:
         return yaml_proto(config_path, ForchConfig)
     except Exception as e:
-        LOGGER.error('Cannot load config: %s', e)
+        logger.error('Cannot load config: %s', e)
         return None
 
 
@@ -38,9 +39,11 @@ def show_error(error, path, params):
 
 def run_forchestrator():
     """main function to start forch"""
+    logger = get_logger(_LOGGER_NAME)
+
     config = load_config()
     if not config:
-        LOGGER.error('Invalid config, exiting.')
+        logger.error('Invalid config, exiting.')
         sys.exit(1)
 
     forchestrator = Forchestrator(config)
@@ -58,7 +61,7 @@ def run_forchestrator():
         http_server.map_request('sys_config', forchestrator.get_sys_config)
         http_server.map_request('', http_server.static_file(''))
     except Exception as e:
-        LOGGER.error("Cannot initialize forch: %s", e, exc_info=True)
+        logger.error("Cannot initialize forch: %s", e, exc_info=True)
         http_server.map_request('', functools.partial(show_error, e))
     finally:
         http_server.start_server()
@@ -69,9 +72,9 @@ def run_forchestrator():
         try:
             http_server.join_thread()
         except KeyboardInterrupt:
-            LOGGER.info('Keyboard interrupt. Exiting.')
+            logger.info('Keyboard interrupt. Exiting.')
 
-    LOGGER.warning('Exiting program')
+    logger.warning('Exiting program')
     http_server.stop_server()
     forchestrator.stop()
 
@@ -92,7 +95,6 @@ def main():
         print(f'Forch {__version__}')
         sys.exit()
 
-    LOGGER.info('Starting Forchestrator')
     run_forchestrator()
 
 

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -42,7 +42,7 @@ def get_logger(name, stdout=False):
         else:
             log_file_path = os.getenv('FORCH_LOG', _LOG_FILE_DEFAULT)
             os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
-            log_handler = logging.handlers.WatchedFileHandler(log_file_path)
+            log_handler = WatchedFileHandler(log_file_path)
 
         log_handler.setFormatter(logging.Formatter(_LOG_FORMAT, _LOG_DATE_FORMAT))
         log_handler.setLevel(logging_level)

--- a/forch/utils.py
+++ b/forch/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for forch"""
 
 import logging
+from logging.handlers import WatchedFileHandler
 import os
 import yaml
 
@@ -30,20 +31,23 @@ class MetricsFetchingError(Exception):
 
 def get_logger(name, stdout=False):
     """Get a logger"""
-    if stdout:
-        log_handler = logging.StreamHandler()
-    else:
-        log_file_path = os.getenv('FORCH_LOG', _LOG_FILE_DEFAULT)
-        os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
-        log_handler = logging.FileHandler(log_file_path)
-
     logging_level = os.getenv('FORCH_LOG_LEVEL', _LOG_LEVEL_DEFAULT)
-    log_handler.setFormatter(logging.Formatter(_LOG_FORMAT, _LOG_DATE_FORMAT))
-    log_handler.setLevel(logging_level)
 
     logger = logging.getLogger(name)
     logger.setLevel(logging_level)
-    logger.addHandler(log_handler)
+
+    if not logger.hasHandlers():
+        if stdout:
+            log_handler = logging.StreamHandler()
+        else:
+            log_file_path = os.getenv('FORCH_LOG', _LOG_FILE_DEFAULT)
+            os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+            log_handler = logging.handlers.WatchedFileHandler(log_file_path)
+
+        log_handler.setFormatter(logging.Formatter(_LOG_FORMAT, _LOG_DATE_FORMAT))
+        log_handler.setLevel(logging_level)
+
+        logger.addHandler(log_handler)
 
     return logger
 


### PR DESCRIPTION
* `get_logger(name)` returns the same instance when getting the logger with the same `name`. So making a change to avoid adding new file handler to logger if it is already added, otherwise there will be many open log files.
* Using `WatchedFileHandler` instead of `FileHandler` since we are using logrotate.
* Moved global variable `LOGGER` in `__main__.py` to local variables in functions since when we import his file we should not import his global variable