### PR TITLE
Initialize logger before calling parent constructor in RequestHandler

### DIFF
--- a/forch/http_server.py
+++ b/forch/http_server.py
@@ -29,8 +29,8 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
 
     def __init__(self, context, *args, **kwargs):
         self._context = context
-        super().__init__(*args, **kwargs)
         self._logger = get_logger('httpserv')
+        super().__init__(*args, **kwargs)
 
     # pylint: disable=invalid-name
     def do_GET(self):


### PR DESCRIPTION
The `Requesthandler` handles the HTTP request in do_GET() which is called in the parent constructor (`super().__init__()`). The problem was that the logger is initialized after parent constructor is called. As a result, it will complain "handler has no _logger attribute" when handling the http request, since the logger is not initialized yet.