### PR TITLE
Initialize faucet_config_summary with empty protobuf message

### DIFF
--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -112,7 +112,7 @@ class Forchestrator(VarzUpdater):
 
         self._config_errors = {}
         self._system_errors = {}
-        self._faucet_config_summary = None
+        self._faucet_config_summary = SystemState.ConfigSummary()
         self._metrics = None
         self._varz_proxy = None
 


### PR DESCRIPTION
Avoid exception in get_system_state() which is caused by copying NoneType to protobuf message.