### PR TITLE
Refactor DeviceReportServer methods with interface

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,7 @@ output-format=parseable
 disable=F0401,R0201,R0902,W0703,I0011,W0403,E1102,R0903,E0611,W0511,W0613
 max-line-length=100
 ignored-classes=
-    State, SystemState, CpnState, CpnConfig,
+    State, SystemState, CpnState, CpnConfig, SummarySources, ConfigSummary,
     FaucetEvent, ProcessState, DataplaneState, SwitchState, PortType,
     BuildingSchema, LacpState, LacpRole, AuthResult, DVAState,
     DevicesState, DevicePlacement, DeviceBehavior, SegmentsToVlans,

--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -109,7 +109,7 @@ VLAN_PACKET_COUNT_METRIC = 'flow_packet_count_vlan'
 # pylint: disable=too-many-public-methods
 class FaucetStateCollector:
     """Processing faucet events and store states in the map"""
-    def __init__(self, config, is_faucetizer_enabled, device_state_reporter=None):
+    def __init__(self, config, is_faucetizer_enabled):
         self.switch_states = {}
         self.topo_state = {}
         self.learned_macs = {}
@@ -131,10 +131,10 @@ class FaucetStateCollector:
         self._stack_state_update = 0
         self._stack_state_data = None
         self._forch_metrics = None
+        self._device_state_reporter = None
         self._config = config
         self._change_coalesce_sec = config.event_client.stack_topo_change_coalesce_sec
         self._packet_per_sec_thresholds = config.dataplane_monitoring.vlan_pkt_per_sec_thresholds
-        self._device_state_reporter = device_state_reporter
 
     def set_active(self, active_state):
         """Set active state"""
@@ -1483,6 +1483,10 @@ class FaucetStateCollector:
     def set_forch_metrics(self, forch_metrics):
         """set object that handles forch varz metrics exposure"""
         self._forch_metrics = forch_metrics
+
+    def set_device_state_reporter(self, device_state_reporter):
+        """set object that processes and reports device related states"""
+        self._device_state_reporter = device_state_reporter
 
     def _get_lacp_link_state(self, lacp_role, lacp_state):
         """Return forch link state for given  faucet lacp role and state"""

--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -1168,7 +1168,7 @@ class FaucetStateCollector:
                     self._update_learned_macs_metric(mac, name, port)
 
                 if self._device_state_reporter:
-                    self._device_state_reporter.process_port_learn(mac, vid)
+                    self._device_state_reporter.process_port_learn(name, port, mac, vid)
 
     @_dump_states
     def process_port_expire(self, timestamp, name, port, mac, expired_vlan=None):

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -223,10 +223,9 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
                 self._faucetizer.reload_segments_to_vlans(self._segments_vlans_file)
 
         sequester_segment, grpc_server_port = self._calculate_sequester_config()
-        handle_device_result = (
-            lambda result: self._port_state_manager.handle_testing_result(result))
         if sequester_segment:
-            self._device_report_server = DeviceReportServer(handle_device_result, grpc_server_port)
+            self._device_report_server = DeviceReportServer(
+                self._handle_device_result, grpc_server_port)
             self._faucet_collector.set_device_state_reporter(self._device_report_server)
 
         self._port_state_manager = PortStateManager(
@@ -294,6 +293,9 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
 
         for mac, device_behavior in devices_state.device_mac_behaviors.items():
             self._port_state_manager.handle_static_device_behavior(mac, device_behavior)
+
+    def _handle_device_result(self, device_result):
+        self._port_state_manager.handle_testing_result(device_result)
 
     def update_device_state_varz(self, mac, state):
         if self._metrics:

--- a/forch/port_state_manager.py
+++ b/forch/port_state_manager.py
@@ -248,11 +248,12 @@ class PortStateManager:
 
     def _set_port_sequestered(self, mac):
         """Set port to sequester vlan"""
-        operational_behavior = (
-            self._static_device_behaviors.get(mac) or self._dynamic_device_behaviors.get(mac))
-        assert operational_behavior
-        operational_vlan = self._get_vlan_from_segment(operational_behavior.segment)
         if self._device_state_reporter:
+            operational_behavior = (
+                self._static_device_behaviors.get(mac) or self._dynamic_device_behaviors.get(mac))
+            assert operational_behavior, f'No operational device behavior available for {mac}'
+            operational_vlan = self._get_vlan_from_segment(operational_behavior.segment)
+            assert operational_vlan, f'No operational vlan available for device {mac}'
             self._device_state_reporter.process_port_assign(mac, operational_vlan)
 
         device_behavior = DeviceBehavior(segment=self._testing_segment)

--- a/forch/port_state_manager.py
+++ b/forch/port_state_manager.py
@@ -248,10 +248,10 @@ class PortStateManager:
 
     def _set_port_sequestered(self, mac):
         """Set port to sequester vlan"""
-        device_behavior = (
+        operational_behavior = (
             self._static_device_behaviors.get(mac) or self._dynamic_device_behaviors.get(mac))
-        assert device_behavior
-        operational_vlan = self._get_vlan_from_segment(device_behavior.segment)
+        assert operational_behavior
+        operational_vlan = self._get_vlan_from_segment(operational_behavior.segment)
         if self._device_state_reporter:
             self._device_state_reporter.process_port_assign(mac, operational_vlan)
 

--- a/testing/python_lib/test_fot.py
+++ b/testing/python_lib/test_fot.py
@@ -160,7 +160,7 @@ class FotDeviceReportServicerTestCase(DeviceReportServicerTestBase):
     def _send_port_change_event(self, kind, args):
         dp_name, port, mac, state, vlan, assigned = args
         if kind == 'port':
-            self._servicer.process_port_change(dp_name, port, state)
+            self._servicer.process_port_state(dp_name, port, state)
         elif kind == 'lern':
             self._servicer.process_port_learn(dp_name, port, mac, vlan)
         elif kind == 'asgn':


### PR DESCRIPTION
* Added interface `DeviceStateReporter`
* Make Forch only report applied vlan to DAQ, when device has both static and dynamic vlan assignment