### PR TITLE
Validate tail_acl and segments_vlans_file during Forch initialization

### DIFF
--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -225,6 +225,7 @@ class Faucetizer(DeviceStateManager):
     def _finalize_host_ports_config(self, behavioral_faucet_config, new_testing_device_vlans):
         testing_port_vlans = new_testing_device_vlans.values()
         testing_port_configured = False
+        should_apply_tail_acl = self._config.tail_acl and self.validate_tail_acl_config()
 
         for switch_map in behavioral_faucet_config.get('dps', {}).values():
             for port_map in switch_map.get('interfaces', {}).values():
@@ -232,8 +233,7 @@ class Faucetizer(DeviceStateManager):
                 if port_type == PortType.testing and testing_port_vlans:
                     port_map.setdefault('tagged_vlans', []).extend(testing_port_vlans)
                     testing_port_configured = True
-                if (self._get_port_type(port_map) == PortType.access and
-                        self.validate_tail_acl_config()):
+                if self._get_port_type(port_map) == PortType.access and should_apply_tail_acl:
                     port_map.setdefault('acls_in', []).append(self._config.tail_acl)
 
         if testing_port_vlans and not testing_port_configured:

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -225,7 +225,8 @@ class Faucetizer(DeviceStateManager):
     def _finalize_host_ports_config(self, behavioral_faucet_config, new_testing_device_vlans):
         testing_port_vlans = new_testing_device_vlans.values()
         testing_port_configured = False
-        has_tail_acl = self._config.tail_acl and self._has_acl(self._config.tail_acl)
+        tail_acl = self._config.tail_acl
+        has_tail_acl = tail_acl and self.validate_tail_acl_config(tail_acl)
 
         for switch_map in behavioral_faucet_config.get('dps', {}).values():
             for port_map in switch_map.get('interfaces', {}).values():

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -122,7 +122,7 @@ class Faucetizer(DeviceStateManager):
 
             self.flush_behavioral_config()
 
-    def validate_tail_acl_config(self):
+    def tail_acl_config_valid(self):
         """Validate tail_acl config"""
         return not self._config.tail_acl or self._has_acl(self._config.tail_acl)
 
@@ -225,7 +225,7 @@ class Faucetizer(DeviceStateManager):
     def _finalize_host_ports_config(self, behavioral_faucet_config, new_testing_device_vlans):
         testing_port_vlans = new_testing_device_vlans.values()
         testing_port_configured = False
-        should_apply_tail_acl = self._config.tail_acl and self.validate_tail_acl_config()
+        apply_tail_acl = self._config.tail_acl and self.tail_acl_config_valid()
 
         for switch_map in behavioral_faucet_config.get('dps', {}).values():
             for port_map in switch_map.get('interfaces', {}).values():
@@ -233,7 +233,7 @@ class Faucetizer(DeviceStateManager):
                 if port_type == PortType.testing and testing_port_vlans:
                     port_map.setdefault('tagged_vlans', []).extend(testing_port_vlans)
                     testing_port_configured = True
-                if self._get_port_type(port_map) == PortType.access and should_apply_tail_acl:
+                if self._get_port_type(port_map) == PortType.access and apply_tail_acl:
                     port_map.setdefault('acls_in', []).append(self._config.tail_acl)
 
         if testing_port_vlans and not testing_port_configured:

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -122,6 +122,10 @@ class Faucetizer(DeviceStateManager):
 
             self.flush_behavioral_config()
 
+    def validate_tail_acl_config(self, tail_acl):
+        """Validate tail_acl config"""
+        return self._has_acl(tail_acl)
+
     def _process_structural_config(self, faucet_config):
         """Process faucet config when structural faucet config changes"""
         with self._lock:
@@ -140,10 +144,6 @@ class Faucetizer(DeviceStateManager):
 
             structural_acls_config = copy.deepcopy(self._structural_faucet_config.get('acls'))
             self._augment_acls_config(structural_acls_config, self._structural_config_file, )
-
-            tail_acl_name = self._config.tail_acl
-            if tail_acl_name and not self._has_acl(tail_acl_name):
-                raise Exception('No ACL is defined for tail ACL %s' % tail_acl_name)
 
             self._behavioral_include = behavioral_include
 
@@ -225,13 +225,15 @@ class Faucetizer(DeviceStateManager):
     def _finalize_host_ports_config(self, behavioral_faucet_config, new_testing_device_vlans):
         testing_port_vlans = new_testing_device_vlans.values()
         testing_port_configured = False
+        has_tail_acl = self._config.tail_acl and self._has_acl(self._config.tail_acl)
+
         for switch_map in behavioral_faucet_config.get('dps', {}).values():
             for port_map in switch_map.get('interfaces', {}).values():
                 port_type = self._get_port_type(port_map)
                 if port_type == PortType.testing and testing_port_vlans:
                     port_map.setdefault('tagged_vlans', []).extend(testing_port_vlans)
                     testing_port_configured = True
-                if self._get_port_type(port_map) == PortType.access and self._config.tail_acl:
+                if self._get_port_type(port_map) == PortType.access and has_tail_acl:
                     port_map.setdefault('acls_in', []).append(self._config.tail_acl)
 
         if testing_port_vlans and not testing_port_configured:

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -223,7 +223,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
 
             tail_acl = self._config.orchestration.tail_acl
             if tail_acl and not self._faucetizer.validate_tail_acl_config(tail_acl):
-                error_msg = 'DVA auth was disabled due to missing ACL for tail_acl config'
+                error_msg = 'All auth was disabled due to missing ACL for tail_acl config'
                 self._logger.error(error_msg)
                 with self._states_lock:
                     self._should_ignore_static_behavior = True
@@ -236,7 +236,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
                 try:
                     self._faucetizer.reload_segments_to_vlans(self._segments_vlans_file)
                 except Exception as error:
-                    error_msg = ('DVA auth was disabled due to error when reading '
+                    error_msg = ('All auth was disabled due to error when reading '
                                  'segments-to-vlans file')
                     self._should_ignore_static_behavior = True
                     self._should_ignore_auth_result = True
@@ -300,7 +300,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
         try:
             devices_state = yaml_proto(file_path, DevicesState)
         except Exception as error:
-            msg = f'Authentication disabled: could not load static behavior file {file_path}'
+            msg = f'Dynamic auth disabled: could not load static behavior file {file_path}'
             self._logger.error('%s: %s', msg, error)
             with self._states_lock:
                 self._config_errors[STATIC_BEHAVIORAL_FILE] = msg

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -221,8 +221,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
             self._initialize_faucetizer(sequester_segment)
             self._faucetizer.reload_structural_config()
 
-            tail_acl = self._config.orchestration.tail_acl
-            if tail_acl and not self._faucetizer.validate_tail_acl_config(tail_acl):
+            if not self._faucetizer.validate_tail_acl_config():
                 error_msg = 'All auth was disabled due to missing ACL for tail_acl config'
                 self._logger.error(error_msg)
                 with self._states_lock:

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -71,7 +71,7 @@ _TARGET_GAUGE_METRICS = (
 ACTIVE_STATE = 'active_state'
 STATIC_BEHAVIORAL_FILE = 'static_behavior_file'
 SEGMENTS_VLANS_FILE = 'segments_vlans_file'
-ACL_CONFIG = 'acl_config'
+TAIL_ACL_CONFIG = 'tail_acl_config'
 SEQUESTER_SEGMENT_DEFAULT = 'SEQUESTER'
 
 
@@ -223,12 +223,12 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
 
             tail_acl = self._config.orchestration.tail_acl
             if tail_acl and not self._faucetizer.validate_tail_acl_config(tail_acl):
-                error_msg = f'DVA auth was disabled due to missing ACL for tail_acl config'
+                error_msg = 'DVA auth was disabled due to missing ACL for tail_acl config'
                 self._logger.error(error_msg)
                 with self._states_lock:
                     self._should_ignore_static_behavior = True
                     self._should_ignore_auth_result = True
-                    self._config_errors[ACL_CONFIG] = error_msg
+                    self._config_errors[TAIL_ACL_CONFIG] = error_msg
 
             if self._gauge_config_file:
                 self._faucetizer.reload_and_flush_gauge_config(self._gauge_config_file)

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -221,7 +221,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
             self._initialize_faucetizer(sequester_segment)
             self._faucetizer.reload_structural_config()
 
-            if not self._faucetizer.validate_tail_acl_config():
+            if not self._faucetizer.tail_acl_config_valid():
                 error_msg = 'All auth was disabled due to missing ACL for tail_acl config'
                 self._logger.error(error_msg)
                 with self._states_lock:
@@ -360,7 +360,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
             with self._states_lock:
                 self._should_ignore_static_behavior = True
                 self._should_ignore_auth_result = True
-                self._logger.info('DVA auth was disabled as segments_vlans_file is not configured')
+                self._logger.info('All auth was disabled as segments_vlans_file is not configured')
 
         return True
 

--- a/forch/port_state_manager.py
+++ b/forch/port_state_manager.py
@@ -294,7 +294,7 @@ class PortStateManager:
 
     def _get_vlan_from_segment(self, segment):
         if self._device_state_manager:
-            return self._device_state_manager.get_vlan_from_segment(segment)
+            return self._device_state_manager.get_vlan_from_segment(segment) or INVALID_VLAN
         return INVALID_VLAN
 
     def _update_device_state_varz(self, mac, device_state):

--- a/testing/python_lib/test_faucetizer.py
+++ b/testing/python_lib/test_faucetizer.py
@@ -412,16 +412,52 @@ class FaucetizerMissingTailACLDefinitionTestCase(FaucetizerTestBase):
             description: HOST
             max_hosts: 1
     acls:
+      uniform_100:
+        - rule:
+            actions:
+              allow: False
       tail_acl:
         - rule:
             actions:
               allow: True
     """
 
+    FAUCET_BEHAVIORAL_CONFIG = """
+    dps:
+      t2sw1:
+        dp_id: 121
+        interfaces:
+          1:
+            description: HOST
+            max_hosts: 1
+            native_vlan: 100
+    acls:
+      uniform_100:
+        - rule:
+            cookie: 1
+            actions:
+              allow: False
+      tail_acl:
+        - rule:
+            cookie: 2
+            actions:
+              allow: True
+    """
+
+    def setUp(self):
+        """setup fixture for each test method"""
+        self._setup_config_files()
+        self._initialize_faucetizer()
+
+    def tearDown(self):
+        """cleanup after each test method finishes"""
+        self._faucetizer = None
+        self._cleanup_config_files()
+
     def test_no_tail_acl_definition(self):
         """test faucetizer behavior when no ACL is defined for tail_acl"""
-        self._setup_config_files()
-        self.assertRaises(Exception, self._initialize_faucetizer)
+        self._faucetizer.reload_structural_config()
+        self._verify_behavioral_config(self._get_base_behavioral_config())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The main idea of this change is that if either of these two configs are invalid (specifed acl/file does not existing, file reading error, etc.), Forch will continue to run with static and dynamic auth disabled. Forch will also display the detailed error on NOAH.

