### PR TITLE
Update vrrp_state map in place

### DIFF
--- a/forch/local_state_collector.py
+++ b/forch/local_state_collector.py
@@ -324,7 +324,7 @@ class LocalStateCollector:
             error_detail = f'Cannot get VRRP info: {e}'
 
         finally:
-            self._vrrp_state = self._handle_vrrp_state(vrrp_state, error_detail)
+            self._vrrp_state.update(self._handle_vrrp_state(vrrp_state, error_detail))
 
     def _handle_vrrp_state(self, vrrp_state, error_detail=None):
         """Extract vrrp state from keepalived stats data"""
@@ -343,8 +343,10 @@ class LocalStateCollector:
                 error_detail)
 
             if vrrp_state == VRRP_MASTER:
+                vrrp_map['vrrp_state_detail'] = None
                 self._active_state_handler(State.active)
             elif vrrp_state == VRRP_BACKUP:
+                vrrp_map['vrrp_state_detail'] = None
                 self._active_state_handler(State.inactive)
             elif vrrp_state == VRRP_FAULT:
                 vrrp_map['vrrp_state_detail'] = 'VRRP is in fault state'


### PR DESCRIPTION
There is a problem with direct assignment in local_state_collector.py at line 327. When calculating the new vrrp_state map, if the state does not change, the `change_count` and `last_change` fields will be empty. If we directly assign the new vrrp_state map to `self._vrrp_state`, the change_count and last_change information would be lost.

With `update()`, `self._vrrp_state` can preserve the entries that are not changed.