### PR TITLE
Always use lowercase MAC in PortStateManager

### DIFF
--- a/forch/cpn_state_collector.py
+++ b/forch/cpn_state_collector.py
@@ -59,7 +59,7 @@ class CPNStateCollector:
         cpn_dir_name = os.getenv('FORCH_CONFIG_DIR')
         cpn_file_name = os.path.join(cpn_dir_name, 'cpn.yaml')
         current_time = datetime.now().isoformat()
-        self._logger.info("Loading CPN config file: %s", cpn_file_name)
+        self._logger.info("Reading CPN config file: %s", cpn_file_name)
         try:
             cpn_data = yaml_proto(cpn_file_name, CpnConfig)
             cpn_nodes = cpn_data.cpn_nodes

--- a/forch/faucetizer.py
+++ b/forch/faucetizer.py
@@ -376,6 +376,7 @@ class Faucetizer(DeviceStateManager):
 
     def reload_and_flush_gauge_config(self, gauge_config_file):
         """Reload gauge config file and rewrite to faucet config directory"""
+        self._logger.info('Reading Gauge config file: %s', gauge_config_file)
         with open(gauge_config_file) as file:
             gauge_config = yaml.safe_load(file)
 
@@ -401,6 +402,7 @@ class Faucetizer(DeviceStateManager):
 
     def reload_segments_to_vlans(self, file_path):
         """Reload file that contains the mappings from segments to vlans"""
+        self._logger.info('Reading segments-to-vlans file: %s', file_path)
         self._segments_to_vlans = yaml_proto(file_path, SegmentsToVlans).segments_to_vlans
 
         operational_vlans = set(self._segments_to_vlans.values())

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -817,7 +817,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
                 is_stack = 1 if 'stack' in if_obj else 0
                 is_access = 1 if 'native_vlan' in if_obj else 0
                 is_tap = 1 if if_obj['description'] == 'tap' else 0
-                is_mirror = 1 if if_obj['description'].lower() == 'mirror' else 0
+                is_mirror = 1 if if_obj['description'] == 'MIRROR' else 0
                 if (is_egress + is_stack + is_access + is_tap + is_mirror) != 1:
                     warnings.append((if_key, 'misconfigured interface config: %d %d %d %d %d' %
                                      (is_egress, is_stack, is_access, is_tap, is_mirror)))

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -296,6 +296,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
         self._port_state_manager.clear_static_device_behaviors()
 
         try:
+            self._logger.info('Reading static device behavior file: %s', file_path)
             devices_state = yaml_proto(file_path, DevicesState)
         except Exception as error:
             msg = f'Dynamic auth disabled: could not load static behavior file {file_path}'
@@ -816,7 +817,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
                 is_stack = 1 if 'stack' in if_obj else 0
                 is_access = 1 if 'native_vlan' in if_obj else 0
                 is_tap = 1 if if_obj['description'] == 'tap' else 0
-                is_mirror = 1 if if_obj['description'] == 'mirror' else 0
+                is_mirror = 1 if if_obj['description'].lower() == 'mirror' else 0
                 if (is_egress + is_stack + is_access + is_tap + is_mirror) != 1:
                     warnings.append((if_key, 'misconfigured interface config: %d %d %d %d %d' %
                                      (is_egress, is_stack, is_access, is_tap, is_mirror)))

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -816,7 +816,7 @@ class Forchestrator(VarzUpdater, OrchestrationManager):
                 is_egress = 1 if 'lacp' in if_obj else 0
                 is_stack = 1 if 'stack' in if_obj else 0
                 is_access = 1 if 'native_vlan' in if_obj else 0
-                is_tap = 1 if if_obj['description'] == 'tap' else 0
+                is_tap = 1 if if_obj['description'] == 'TAP' else 0
                 is_mirror = 1 if if_obj['description'] == 'MIRROR' else 0
                 if (is_egress + is_stack + is_access + is_tap + is_mirror) != 1:
                     warnings.append((if_key, 'misconfigured interface config: %d %d %d %d %d' %

--- a/forch/port_state_manager.py
+++ b/forch/port_state_manager.py
@@ -125,27 +125,30 @@ class PortStateManager:
     def handle_static_device_behavior(self, mac, device_behavior):
         """Add static testing state for a device"""
         with self._lock:
+            mac_lower = mac.lower()
             static_port_behavior = device_behavior.port_behavior
             if static_port_behavior:
-                self._static_port_behaviors[mac] = static_port_behavior
+                self._static_port_behaviors[mac_lower] = static_port_behavior
 
             if device_behavior.segment:
-                self.handle_device_behavior(mac, device_behavior, static=True)
+                self.handle_device_behavior(mac_lower, device_behavior, static=True)
 
     def handle_device_behavior(self, mac, device_behavior, static=False):
         """Handle authentication result"""
+        mac_lower = mac.lower()
         if device_behavior.segment:
-            self._handle_authenticated_device(mac, device_behavior, static)
+            self._handle_authenticated_device(mac_lower, device_behavior, static)
             if static:
                 self._update_static_vlan_varz(
-                    mac, vlan=self._get_vlan_from_segment(device_behavior.segment))
+                    mac_lower, vlan=self._get_vlan_from_segment(device_behavior.segment))
         else:
-            self._handle_deauthenticated_device(mac, static)
+            self._handle_deauthenticated_device(mac_lower, static)
 
     def handle_device_placement(self, mac, device_placement, static=False):
         """Handle a learning or expired VLAN for a device"""
         if device_placement.connected:
-            return self._handle_learned_device(mac, device_placement, static)
+            mac_lower = mac.lower()
+            return self._handle_learned_device(mac_lower, device_placement, static)
 
         return self._handle_disconnected_device(device_placement)
 
@@ -232,7 +235,8 @@ class PortStateManager:
     def handle_testing_result(self, testing_result):
         """Update the state machine for a device according to the testing result"""
         for mac, device_behavior in testing_result.device_mac_behaviors.items():
-            self._handle_port_behavior(mac, device_behavior.port_behavior)
+            mac_lower = mac.lower()
+            self._handle_port_behavior(mac_lower, device_behavior.port_behavior)
 
     def _handle_port_behavior(self, mac, port_behavior):
         with self._lock:

--- a/testing/python_lib/build_config.py
+++ b/testing/python_lib/build_config.py
@@ -87,7 +87,7 @@ class FaucetConfigGenerator():
                 description='egress', tagged_vlans=tagged_vlans)
 
     def _add_tap_interface(self, interfaces, tap_vlan):
-        interfaces[TAP_PORT] = Interface(description='tap', tagged_vlans=[tap_vlan])
+        interfaces[TAP_PORT] = Interface(description='TAP', tagged_vlans=[tap_vlan])
 
     def _add_flat_link_interfaces(self, interfaces, dps, dp_index):
         if dp_index < len(dps) - 1:

--- a/testing/python_lib/test_fot.py
+++ b/testing/python_lib/test_fot.py
@@ -265,21 +265,21 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
         dynamic_device_placements = {
             '00:0X:00:00:00:01': {'switch': 't2sw1', 'port': 1, 'connected': True},
             '00:0A:00:00:00:04': {'switch': 't2sw4', 'port': 4, 'connected': True},
-            '00:0B:00:00:00:05': {'switch': 't2sw5', 'port': 5, 'connected': True}
+            '00:0b:00:00:00:05': {'switch': 't2sw5', 'port': 5, 'connected': True}
         }
         static_device_behaviors = {
-            '00:0X:00:00:00:01': {'segment': 'SEG_A', 'port_behavior': 'cleared'},
+            '00:0x:00:00:00:01': {'segment': 'SEG_A', 'port_behavior': 'cleared'},
             '00:0Y:00:00:00:02': {'port_behavior': 'cleared'}
         }
         authentication_results = {
             '00:0X:00:00:00:01': {'segment': 'SEG_X'},
             '00:0Z:00:00:00:03': {'segment': 'SEG_C'},
-            '00:0A:00:00:00:04': {'segment': 'SEG_D'},
+            '00:0a:00:00:00:04': {'segment': 'SEG_D'},
             '00:0B:00:00:00:05': {'segment': 'SEG_E'}
         }
         testing_results = [
             ('00:0X:00:00:00:01', 'failed'),
-            ('00:0Y:00:00:00:02', 'passed'),
+            ('00:0y:00:00:00:02', 'passed'),
             ('00:0Z:00:00:00:03', 'failed'),
             ('00:0A:00:00:00:04', 'passed')
         ]
@@ -325,8 +325,8 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
 
         expected_device_placements.extend([
             # mac, connected, static
-            ('00:0Y:00:00:00:02', True, True),
-            ('00:0Z:00:00:00:03', True, True),
+            ('00:0y:00:00:00:02', True, True),
+            ('00:0z:00:00:00:03', True, True),
         ])
         self._verify_received_device_placements(expected_device_placements)
 
@@ -336,8 +336,8 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
                 mac, dict_proto(device_behavior_map, DeviceBehavior))
 
         expected_states = {
-            '00:0Y:00:00:00:02': self.UNAUTHENTICATED,
-            '00:0Z:00:00:00:03': self.UNAUTHENTICATED
+            '00:0y:00:00:00:02': self.UNAUTHENTICATED,
+            '00:0z:00:00:00:03': self.UNAUTHENTICATED
         }
         self._verify_ports_states(expected_states)
 
@@ -347,9 +347,9 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
                 device_placement_map, DevicePlacement), static=False)
 
         expected_device_placements.extend([
-            ('00:0X:00:00:00:01', True, False),
-            ('00:0A:00:00:00:04', True, False),
-            ('00:0B:00:00:00:05', True, False)
+            ('00:0x:00:00:00:01', True, False),
+            ('00:0a:00:00:00:04', True, False),
+            ('00:0b:00:00:00:05', True, False)
         ])
         self._verify_received_device_placements(expected_device_placements)
 
@@ -359,20 +359,20 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
                 mac, dict_proto(device_behavior_map, DeviceBehavior))
 
         expected_states = {
-            '00:0X:00:00:00:01': self.OPERATIONAL,
-            '00:0Y:00:00:00:02': self.UNAUTHENTICATED,
-            '00:0Z:00:00:00:03': self.SEQUESTERED,
-            '00:0A:00:00:00:04': self.SEQUESTERED,
-            '00:0B:00:00:00:05': self.SEQUESTERED
+            '00:0x:00:00:00:01': self.OPERATIONAL,
+            '00:0y:00:00:00:02': self.UNAUTHENTICATED,
+            '00:0z:00:00:00:03': self.SEQUESTERED,
+            '00:0a:00:00:00:04': self.SEQUESTERED,
+            '00:0b:00:00:00:05': self.SEQUESTERED
         }
         self._verify_ports_states(expected_states)
 
         expected_device_behaviors.extend([
-            ('00:0X:00:00:00:01', 'SEG_A', True),
-            ('00:0X:00:00:00:01', 'SEG_A', True),
-            ('00:0Z:00:00:00:03', 'TESTING', False),
-            ('00:0A:00:00:00:04', 'TESTING', False),
-            ('00:0B:00:00:00:05', 'TESTING', False)
+            ('00:0x:00:00:00:01', 'SEG_A', True),
+            ('00:0x:00:00:00:01', 'SEG_A', True),
+            ('00:0z:00:00:00:03', 'TESTING', False),
+            ('00:0a:00:00:00:04', 'TESTING', False),
+            ('00:0b:00:00:00:05', 'TESTING', False)
         ])
         self._verify_received_device_behaviors(expected_device_behaviors)
 
@@ -382,17 +382,17 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
                 self._encapsulate_testing_result(*testing_result))
 
         expected_states = {
-            '00:0X:00:00:00:01': self.OPERATIONAL,
-            '00:0Y:00:00:00:02': self.UNAUTHENTICATED,
-            '00:0Z:00:00:00:03': self.INFRACTED,
-            '00:0A:00:00:00:04': self.OPERATIONAL,
-            '00:0B:00:00:00:05': self.SEQUESTERED
+            '00:0x:00:00:00:01': self.OPERATIONAL,
+            '00:0y:00:00:00:02': self.UNAUTHENTICATED,
+            '00:0z:00:00:00:03': self.INFRACTED,
+            '00:0a:00:00:00:04': self.OPERATIONAL,
+            '00:0b:00:00:00:05': self.SEQUESTERED
         }
         self._verify_ports_states(expected_states)
 
         expected_device_behaviors.extend([
-            ('00:0Z:00:00:00:03', '', False),
-            ('00:0A:00:00:00:04', 'SEG_D', False)
+            ('00:0z:00:00:00:03', '', False),
+            ('00:0a:00:00:00:04', 'SEG_D', False)
         ])
         self._verify_received_device_behaviors(expected_device_behaviors)
 
@@ -406,8 +406,8 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
 
         expected_device_placements.extend([
             # mac, device_placement.connected, static
-            ('00:0X:00:00:00:01', False, False),
-            ('00:0B:00:00:00:05', False, False)
+            ('00:0x:00:00:00:01', False, False),
+            ('00:0b:00:00:00:05', False, False)
         ])
         self._verify_received_device_placements(expected_device_placements)
 
@@ -416,13 +416,13 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
             self._port_state_manager.handle_device_behavior(mac, DeviceBehavior())
 
         expected_states = {
-            '00:0Y:00:00:00:02': self.UNAUTHENTICATED,
-            '00:0Z:00:00:00:03': self.INFRACTED,
-            '00:0A:00:00:00:04': self.UNAUTHENTICATED
+            '00:0y:00:00:00:02': self.UNAUTHENTICATED,
+            '00:0z:00:00:00:03': self.INFRACTED,
+            '00:0a:00:00:00:04': self.UNAUTHENTICATED
         }
         self._verify_ports_states(expected_states)
 
-        expected_device_behaviors.extend([('00:0A:00:00:00:04', '', False)])
+        expected_device_behaviors.extend([('00:0a:00:00:00:04', '', False)])
         self._verify_received_device_behaviors(expected_device_behaviors)
 
     def _reauthenticate_devices(self, reauthenticated_device, expected_device_behaviors):
@@ -431,13 +431,13 @@ class FotPortStatesTestCase(PortsStateManagerTestBase):
                 mac, dict_proto(device_behavior_map, DeviceBehavior))
 
         expected_states = {
-            '00:0Y:00:00:00:02': self.UNAUTHENTICATED,
-            '00:0Z:00:00:00:03': self.INFRACTED,
-            '00:0A:00:00:00:04': self.SEQUESTERED
+            '00:0y:00:00:00:02': self.UNAUTHENTICATED,
+            '00:0z:00:00:00:03': self.INFRACTED,
+            '00:0a:00:00:00:04': self.SEQUESTERED
         }
         self._verify_ports_states(expected_states)
 
-        expected_device_behaviors.extend([('00:0A:00:00:00:04', 'TESTING', False)])
+        expected_device_behaviors.extend([('00:0a:00:00:00:04', 'TESTING', False)])
         self._verify_received_device_behaviors(expected_device_behaviors)
 
 

--- a/topo/bond/faucet/faucet.yaml
+++ b/topo/bond/faucet/faucet.yaml
@@ -8,7 +8,7 @@ dps:
       priority: 1
     interfaces:
       4:
-        description: tap
+        description: TAP
         tagged_vlans: [171, 272]
       6:
         description: "to t1sw2 port 6"

--- a/topo/dva/forch/behaviors.yaml
+++ b/topo/dva/forch/behaviors.yaml
@@ -1,5 +1,5 @@
 device_mac_behaviors:
-  "9a:02:57:1e:8f:01":
+  "9A:02:57:1E:8F:01":
     segment: INFRA
     role: hello_world.foo.bar#bazqux@quuxquuz123
   "02:03:04:00:00:03":

--- a/topo/fot/forch/faucet.yaml
+++ b/topo/fot/forch/faucet.yaml
@@ -8,7 +8,7 @@ dps:
       priority: 1
     interfaces:
       4:
-        description: tap
+        description: TAP
         tagged_vlans: [171]
       6:
         description: "to t1sw2 port 6"

--- a/topo/fot/forch/forch.yaml
+++ b/topo/fot/forch/forch.yaml
@@ -17,7 +17,7 @@ orchestration:
   sequester_config:
     vlan_start: 272
     vlan_end: 276
-    port_description: tap
+    port_description: TAP
 proxy_server:
   targets:
     faucet:

--- a/topo/scale/faucet/faucet.yaml
+++ b/topo/scale/faucet/faucet.yaml
@@ -8,7 +8,7 @@ dps:
       priority: 1
     interfaces:
       4:
-        description: tap
+        description: TAP
         tagged_vlans: [272]
       6:
         description: "to t1sw2 port 6"


### PR DESCRIPTION
There was an issue where static device behavior was defined with uppercase MAC but the corresponding dynamic device placement was learned with lowercase MAC. As a result PortStatemanager treated them as different devices.