### PR TITLE
Use a different process for each device's grpc connection

### DIFF
--- a/forch/device_report_client.py
+++ b/forch/device_report_client.py
@@ -1,10 +1,12 @@
 """Server to handle incoming session requests"""
 
+import signal
 import threading
+import multiprocessing as mp
+
 import grpc
 
 import forch.endpoint_handler as endpoint_handler
-
 from forch.proto.shared_constants_pb2 import PortBehavior
 from forch.proto.devices_state_pb2 import DevicesState
 from forch.base_classes import DeviceStateReporter
@@ -36,10 +38,12 @@ class DeviceReportClient(DeviceStateReporter):
         self._logger = get_logger('devreport')
         self._logger.info('Initializing with unauthenticated vlan %s', unauth_vlan)
         self._logger.info('Using target %s, proto %s', target, bool(PORT_BEHAVIOR_SESSION_RESULT))
-        self._channel = grpc.insecure_channel(target)
-        self._stub = None
+        self._target = target
         self._dp_mac_map = {}
-        self._mac_sessions = {}
+        self._mac_session_processes = {}
+        self._progress_q = mp.Queue()
+        self._progress_q_thread = None
+
         self._mac_device_vlan_map = {}
         self._mac_assigned_vlan_map = {}
         self._unauth_vlan = unauth_vlan
@@ -50,30 +54,42 @@ class DeviceReportClient(DeviceStateReporter):
 
     def start(self):
         """Start the client handler"""
-        grpc.channel_ready_future(self._channel).result(timeout=CONNECT_TIMEOUT_SEC)
-        self._stub = SessionServerStub(self._channel)
+        # Context may be set already even though this function is only called once.
+        try:
+            mp.set_start_method('spawn')
+        except RuntimeError:
+            pass
+        self._progress_q_thread = threading.Thread(target=self._process_progress_q)
+        self._progress_q_thread.start()
 
     def stop(self):
         """Stop client handler"""
+        self._progress_q.put((None, None))
+        if self._progress_q_thread:
+            self._progress_q_thread.join()
 
-    def _connect(self, mac, vlan, assigned):
-        self._logger.info('Connecting %s to %s/%s', mac, vlan, assigned)
+    @classmethod
+    def _connect(cls, mac, vlan, assigned, target, tunnel_ip, progress_q):  # pylint: disable=too-many-arguments
+        channel = grpc.insecure_channel(target)
+        grpc.channel_ready_future(channel).result(timeout=CONNECT_TIMEOUT_SEC)
+        stub = SessionServerStub(channel)
         session_params = SessionParams()
         session_params.device_mac = mac
         session_params.device_vlan = vlan
         session_params.assigned_vlan = assigned
-        session_params.endpoint.ip = self._tunnel_ip or DEFAULT_SERVER_ADDRESS
-        session = self._stub.StartSession(session_params)
-        thread = threading.Thread(target=lambda: self._process_progress(mac, session))
-        thread.start()
-        return session
+        session_params.endpoint.ip = tunnel_ip
+        session = stub.StartSession(session_params)
+        signal.signal(signal.SIGTERM, lambda: session.cancel())
+        for progress in session:
+            progress_q.put((mac, progress))
+        progress_q.put((mac, None))
 
     def disconnect(self, mac):
         with self._lock:
-            session = self._mac_sessions.get(mac)
-            if session:
-                session.cancel()
-                self._mac_sessions.pop(mac)
+            process = self._mac_session_processes.get(mac)
+            if process:
+                process.terminate()
+                self._mac_session_processes.pop(mac)
                 self._logger.info('Device %s disconnected', mac)
             else:
                 self._logger.warning('Attempt to disconnect unconnected device %s', mac)
@@ -99,18 +115,20 @@ class DeviceReportClient(DeviceStateReporter):
                 self._endpoint_handler.process_endpoint(progress.endpoint)
         return False
 
-    def _process_progress(self, mac, session):
-        try:
-            for progress in session:
-                if self._convert_and_handle(mac, progress):
-                    break
-            self._logger.info('Progress complete for %s', mac)
-        except Exception as e:
-            self._logger.error('Progress exception: %s', e)
-        self.disconnect(mac)
+    def _process_progress_q(self):
+        while True:
+            mac, progress = self._progress_q.get(block=True)
+            if not mac: # device client shutdown
+                break
+            try:
+                if not progress or self._convert_and_handle(mac, progress):
+                    self._logger.info('Progress complete for %s', mac)
+                    self.disconnect(mac)
+            except Exception as e:
+                self._logger.error('Progress exception for %s: %s', mac, e)
 
     def _process_session_ready(self, mac):
-        if mac in self._mac_sessions:
+        if mac in self._mac_session_processes:
             self._logger.info('Ignoring b/c existing session %s', mac)
             return
         device_vlan = self._mac_device_vlan_map.get(mac)
@@ -119,7 +137,11 @@ class DeviceReportClient(DeviceStateReporter):
 
         good_device_vlan = device_vlan and device_vlan not in (self._unauth_vlan, assigned_vlan)
         if assigned_vlan and good_device_vlan:
-            self._mac_sessions[mac] = self._connect(mac, device_vlan, assigned_vlan)
+            self._logger.info('Connecting %s to %s/%s', mac, device_vlan, assigned_vlan)
+            self._mac_session_processes[mac] = mp.Process(target=self._connect, args=(mac,
+                device_vlan, assigned_vlan, self._target,
+                self._tunnel_ip or DEFAULT_SERVER_ADDRESS, self._progress_q))
+            self._mac_session_processes[mac].start()
 
     def process_port_state(self, dp_name, port, state):
         """Process faucet port state events"""


### PR DESCRIPTION
GRPC only maintains 1 single channel (connection to the k8s IBL) in each process so LB across all testing devices can't happen. This PR, with no functional change, ensures each device can have its own connection to the IBL for proper LB.
