### PR TITLE
Fetch target_version

### DIFF
--- a/bin/setup_remote
+++ b/bin/setup_remote
@@ -42,8 +42,11 @@ else
 fi
 
 echo Switching $TARGET to version $TARGET_VERSION
-(cd $TARGET
- git checkout --detach --no-guess $TARGET_VERSION -- || git checkout --detach --no-guess origin/$TARGET_VERSION --
+(
+    cd $TARGET
+    # Necessary if target isn't a named branch or tag, a noop otherwise.
+    git fetch origin $TARGET_VERSION
+    git checkout --detach --no-guess $TARGET_VERSION -- || git checkout --detach --no-guess origin/$TARGET_VERSION --
 )
 
 echo -n "Last $TARGET commit: "


### PR DESCRIPTION
This is a minor change to forch to enable CI testing from DAQ to run FOT inside of the DAQ CI (will be in a separate DAQ PR).